### PR TITLE
✨ feat: 로그인/회원가입 페이지 (#2)

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -72,6 +72,8 @@
   padding: 0;
 }
 
+[hidden] { display: none !important; }
+
 html {
   font-size: var(--font-size-base);
   scroll-behavior: smooth;

--- a/css/pages/login.css
+++ b/css/pages/login.css
@@ -1,0 +1,229 @@
+/* ── 로그인 페이지 ── */
+.login-page {
+  min-height: 100vh;
+  background: var(--color-navy-dark);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+}
+
+/* 별 파티클 */
+.stars {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.star {
+  position: absolute;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.7);
+  animation: twinkle 2s infinite alternate;
+}
+
+@keyframes twinkle {
+  from { opacity: 0.15; transform: scale(1); }
+  to   { opacity: 0.85; transform: scale(1.3); }
+}
+
+/* 중앙 카드 */
+.login-card {
+  position: relative;
+  z-index: 1;
+  background: var(--color-surface);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-modal);
+  padding: 40px 36px 36px;
+  width: 100%;
+  max-width: 420px;
+  margin: 20px;
+}
+
+/* 로고 */
+.login-card__logo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 32px;
+}
+
+/* 다크 네이비 앱 아이콘 배지 */
+.login-logo-badge {
+  width: 148px;
+  height: 148px;
+  border-radius: 34px;
+  background: linear-gradient(145deg, #2C4A7C 0%, #1A3258 50%, #0D1B33 100%);
+  box-shadow:
+    0 16px 48px rgba(13, 27, 51, 0.55),
+    0 4px 16px rgba(13, 27, 51, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.13),
+    inset 0 -3px 10px rgba(0, 0, 0, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.login-logo-badge:hover {
+  transform: translateY(-2px);
+  box-shadow:
+    0 20px 56px rgba(13, 27, 51, 0.6),
+    0 6px 20px rgba(13, 27, 51, 0.35),
+    inset 0 1px 0 rgba(255, 255, 255, 0.15),
+    inset 0 -3px 10px rgba(0, 0, 0, 0.25);
+}
+
+.login-logo-badge__gloss {
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 44%;
+  background: linear-gradient(rgba(255, 255, 255, 0.11) 0%, transparent 100%);
+  pointer-events: none;
+  border-radius: inherit;
+}
+
+.login-logo-badge__content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  font-family: var(--font-en);
+  font-size: 23px;
+  font-weight: 700;
+  color: #ffffff;
+  letter-spacing: -0.03em;
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.45);
+  white-space: nowrap;
+  user-select: none;
+}
+
+.logo-eye-slot {
+  display: inline-flex;
+  align-items: center;
+  margin-top: 0.14em;
+}
+
+
+.login-card__tagline {
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+  letter-spacing: 0.01em;
+}
+
+/* 유형 탭 (학생 | 관리자) */
+.login-card__role-tabs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  margin-bottom: 20px;
+  background: var(--color-bg);
+  padding: 4px;
+  border-radius: var(--radius-sm);
+}
+
+.role-tab {
+  padding: 8px;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  transition: background var(--transition-fast), color var(--transition-fast);
+  cursor: pointer;
+  border: none;
+  background: none;
+}
+
+.role-tab.is-active {
+  background: var(--color-surface);
+  color: var(--color-navy-dark);
+  font-weight: 700;
+  box-shadow: var(--shadow-sm);
+}
+
+/* 기능 탭 (로그인 | 회원가입) */
+.login-card__func-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 2px solid var(--color-bg);
+  margin-bottom: 24px;
+}
+
+.func-tab {
+  flex: 1;
+  padding: 10px 0;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  border: none;
+  background: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+  cursor: pointer;
+}
+
+.func-tab.is-active {
+  color: var(--color-blue-primary);
+  border-bottom-color: var(--color-blue-primary);
+}
+
+/* 폼 */
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.form-group__label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+
+.input {
+  width: 100%;
+  padding: 11px 14px;
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: 0.9375rem;
+  font-family: var(--font-ko);
+  color: var(--color-text-primary);
+  background: var(--color-surface);
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+  outline: none;
+}
+
+.input:focus {
+  border-color: var(--color-border-focus);
+  box-shadow: 0 0 0 3px rgba(91, 127, 219, 0.15);
+}
+
+.form-group__error {
+  font-size: 0.78rem;
+  color: var(--color-danger);
+  min-height: 1em;
+}
+
+.btn--full { width: 100%; }
+
+.login-form__submit {
+  margin-top: 4px;
+}
+
+/* 로딩 상태 */
+.btn--loading {
+  pointer-events: none;
+  opacity: 0.7;
+}

--- a/js/api.js
+++ b/js/api.js
@@ -56,16 +56,16 @@ export const AuthApi = {
    * POST /api/v1/auth/signup
    * @returns {{ success, message, data: { userId, email } }}
    */
-  signup(email, password) {
-    return request('POST', '/api/v1/auth/signup', { email, password });
+  signup(email, password, nickname) {
+    return request('POST', '/api/v1/auth/signup', { email, password, nickname });
   },
 
   /**
    * 관리자 회원가입
    * POST /api/v1/auth/admin/signup
    */
-  adminSignup(email, password) {
-    return request('POST', '/api/v1/auth/admin/signup', { email, password });
+  adminSignup(email, password, nickname) {
+    return request('POST', '/api/v1/auth/admin/signup', { email, password, nickname });
   },
 
   /**

--- a/js/auth.js
+++ b/js/auth.js
@@ -81,7 +81,7 @@ export const auth = {
     if (role === 'ADMIN') {
       location.replace(`${getPrefix()}pages/admin/word-manage.html`);
     } else if (role === 'USER') {
-      location.replace(`${getPrefix()}pages/dashboard.html`);
+      location.replace(`${getPrefix()}pages/word-list.html`);
     }
   },
 };

--- a/js/pages/login.js
+++ b/js/pages/login.js
@@ -1,0 +1,161 @@
+import { AuthApi } from '../api.js';
+import { auth } from '../auth.js';
+import { showToast, createEyeSvg } from '../utils.js';
+
+auth.redirectIfLoggedIn();
+
+// ── 로고 눈 렌더링 ────────────────────────────────────────────
+document.getElementById('logoEye').appendChild(createEyeSvg(0.54));
+document.getElementById('logoEye2').appendChild(createEyeSvg(0.54));
+
+// ── 별 파티클 생성 ────────────────────────────────────────────
+(function createStars() {
+  const container = document.getElementById('stars');
+  for (let i = 0; i < 60; i++) {
+    const star = document.createElement('div');
+    star.className = 'star';
+    const size = Math.random() * 3 + 1;
+    star.style.cssText = `
+      width: ${size}px;
+      height: ${size}px;
+      top: ${Math.random() * 100}%;
+      left: ${Math.random() * 100}%;
+      animation-delay: ${Math.random() * 3}s;
+      animation-duration: ${1.5 + Math.random() * 2}s;
+    `;
+    container.appendChild(star);
+  }
+})();
+
+// ── 상태 ─────────────────────────────────────────────────────
+let currentRole = 'student'; // 회원가입 시 사용: 'student' | 'admin'
+
+// ── DOM 참조 ─────────────────────────────────────────────────
+const roleTabsContainer = document.getElementById('roleTabs');
+const roleTabs   = document.querySelectorAll('.role-tab');
+const funcTabs   = document.querySelectorAll('.func-tab');
+const loginForm  = document.getElementById('loginForm');
+const signupForm = document.getElementById('signupForm');
+
+// ── 유형 탭 (학생 | 관리자) ───────────────────────────────────
+roleTabs.forEach(tab => {
+  tab.addEventListener('click', () => {
+    currentRole = tab.dataset.role;
+    roleTabs.forEach(t => t.classList.toggle('is-active', t === tab));
+    clearErrors();
+  });
+});
+
+// ── 기능 탭 (로그인 | 회원가입) ──────────────────────────────
+funcTabs.forEach(tab => {
+  tab.addEventListener('click', () => switchFunc(tab.dataset.func));
+});
+
+function switchFunc(func) {
+  funcTabs.forEach(t => t.classList.toggle('is-active', t.dataset.func === func));
+  // 회원가입일 때만 학생/관리자 탭 표시
+  roleTabsContainer.hidden = func !== 'signup';
+  loginForm.hidden  = func !== 'login';
+  signupForm.hidden = func !== 'signup';
+  clearErrors();
+}
+
+function clearErrors() {
+  document.getElementById('loginError').textContent  = '';
+  document.getElementById('signupError').textContent = '';
+}
+
+// ── 로그인 제출 ───────────────────────────────────────────────
+loginForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const email    = document.getElementById('loginEmail').value.trim();
+  const password = document.getElementById('loginPassword').value;
+  const btn      = document.getElementById('loginBtn');
+  const errorEl  = document.getElementById('loginError');
+
+  if (!isValidEmail(email)) {
+    errorEl.textContent = '올바른 이메일 형식을 입력하세요.';
+    return;
+  }
+  if (!password) {
+    errorEl.textContent = '비밀번호를 입력하세요.';
+    return;
+  }
+
+  btn.classList.add('btn--loading');
+  btn.textContent = '로그인 중...';
+
+  try {
+    const res = await AuthApi.login(email, password);
+    if (!res || !res.success) {
+      errorEl.textContent = res?.message || '로그인에 실패했습니다.';
+      return;
+    }
+    const { role, userId } = res.data;
+    auth.saveSession({ role, userId, email });
+
+    if (role === 'ADMIN') {
+      location.replace('./admin/word-manage.html');
+    } else {
+      location.replace('./word-list.html');
+    }
+  } catch {
+    showToast('네트워크 오류가 발생했습니다.', 'error');
+  } finally {
+    btn.classList.remove('btn--loading');
+    btn.textContent = '로그인';
+  }
+});
+
+// ── 회원가입 제출 ─────────────────────────────────────────────
+signupForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const email    = document.getElementById('signupEmail').value.trim();
+  const nickname = document.getElementById('signupNickname').value.trim();
+  const password = document.getElementById('signupPassword').value;
+  const confirm  = document.getElementById('signupPasswordConfirm').value;
+  const btn      = document.getElementById('signupBtn');
+  const errorEl  = document.getElementById('signupError');
+
+  if (!isValidEmail(email)) {
+    errorEl.textContent = '올바른 이메일 형식을 입력하세요.';
+    return;
+  }
+  if (!nickname) {
+    errorEl.textContent = '닉네임을 입력하세요.';
+    return;
+  }
+  if (!password) {
+    errorEl.textContent = '비밀번호를 입력하세요.';
+    return;
+  }
+  if (password !== confirm) {
+    errorEl.textContent = '비밀번호가 일치하지 않습니다.';
+    return;
+  }
+
+  btn.classList.add('btn--loading');
+  btn.textContent = '가입 중...';
+
+  try {
+    const apiFn = currentRole === 'admin' ? AuthApi.adminSignup : AuthApi.signup;
+    const res = await apiFn(email, password, nickname);
+    if (!res || !res.success) {
+      errorEl.textContent = res?.message || '회원가입에 실패했습니다.';
+      return;
+    }
+    showToast('회원가입이 완료되었습니다!', 'success');
+    signupForm.reset();
+    switchFunc('login');
+  } catch {
+    showToast('네트워크 오류가 발생했습니다.', 'error');
+  } finally {
+    btn.classList.remove('btn--loading');
+    btn.textContent = '회원가입';
+  }
+});
+
+// ── 유틸 ─────────────────────────────────────────────────────
+function isValidEmail(email) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}

--- a/js/utils.js
+++ b/js/utils.js
@@ -160,7 +160,28 @@ export function createEyeSvg(size = 1) {
     hl.setAttribute('cx', (18 + parseFloat(ox) * 0.3).toFixed(2));
     hl.setAttribute('cy', (17 + parseFloat(oy) * 0.3).toFixed(2));
   }
+
+  // 깜박이기 애니메이션
+  let blinkTimer = null;
+  function doBlink() {
+    sclera.style.transition = 'ry 0.07s ease-in';
+    sclera.style.ry = '0.5px';
+    setTimeout(() => {
+      sclera.style.transition = 'ry 0.11s ease-out';
+      sclera.style.ry = '16px';
+    }, 90);
+  }
+
+  svg.addEventListener('mouseenter', () => {
+    doBlink();
+    blinkTimer = setInterval(doBlink, 1800);
+  });
+
   function onMouseLeave() {
+    clearInterval(blinkTimer);
+    blinkTimer = null;
+    sclera.style.transition = 'ry 0.11s ease-out';
+    sclera.style.ry = '16px';
     iris.setAttribute('cx', '22'); iris.setAttribute('cy', '22');
     pupil.setAttribute('cx', '22'); pupil.setAttribute('cy', '22');
     hl.setAttribute('cx', '18'); hl.setAttribute('cy', '17');

--- a/pages/login.html
+++ b/pages/login.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>LookEng — 로그인</title>
+  <link rel="stylesheet" href="../css/global.css" />
+  <link rel="stylesheet" href="../css/components.css" />
+  <link rel="stylesheet" href="../css/pages/login.css" />
+</head>
+<body>
+  <div class="login-page">
+    <div class="stars" id="stars"></div>
+
+    <div class="login-card">
+      <!-- 로고 -->
+      <div class="login-card__logo">
+        <div class="login-logo-badge">
+          <div class="login-logo-badge__gloss"></div>
+          <div class="login-logo-badge__content">
+            <span>L</span>
+            <span class="logo-eye-slot" id="logoEye"></span>
+            <span class="logo-eye-slot" id="logoEye2"></span>
+            <span>kEng</span>
+          </div>
+        </div>
+        <p class="login-card__tagline">영어 단어 학습 플랫폼</p>
+      </div>
+
+      <!-- 기능 탭: 로그인 | 회원가입 -->
+      <div class="login-card__func-tabs">
+        <button class="func-tab is-active" data-func="login">로그인</button>
+        <button class="func-tab" data-func="signup">회원가입</button>
+      </div>
+
+      <!-- 유형 탭: 학생 | 관리자 (회원가입 탭일 때만 표시) -->
+      <div class="login-card__role-tabs" id="roleTabs" hidden>
+        <button class="role-tab is-active" data-role="student">학생</button>
+        <button class="role-tab" data-role="admin">관리자</button>
+      </div>
+
+      <!-- 로그인 폼 -->
+      <form class="login-form" id="loginForm">
+        <div class="form-group">
+          <label class="form-group__label" for="loginEmail">이메일</label>
+          <input type="email" class="input" id="loginEmail" placeholder="example@email.com" autocomplete="email" />
+        </div>
+        <div class="form-group">
+          <label class="form-group__label" for="loginPassword">비밀번호</label>
+          <input type="password" class="input" id="loginPassword" placeholder="비밀번호 입력" autocomplete="current-password" />
+          <p class="form-group__error" id="loginError"></p>
+        </div>
+        <div class="login-form__submit">
+          <button type="submit" class="btn btn--primary btn--full" id="loginBtn">로그인</button>
+        </div>
+      </form>
+
+      <!-- 회원가입 폼 -->
+      <form class="login-form" id="signupForm" hidden>
+        <div class="form-group">
+          <label class="form-group__label" for="signupEmail">이메일</label>
+          <input type="email" class="input" id="signupEmail" placeholder="example@email.com" autocomplete="email" />
+        </div>
+        <div class="form-group">
+          <label class="form-group__label" for="signupNickname">닉네임</label>
+          <input type="text" class="input" id="signupNickname" placeholder="닉네임 입력 (최대 50자)" maxlength="50" autocomplete="nickname" />
+        </div>
+        <div class="form-group">
+          <label class="form-group__label" for="signupPassword">비밀번호</label>
+          <input type="password" class="input" id="signupPassword" placeholder="비밀번호 입력" autocomplete="new-password" />
+        </div>
+        <div class="form-group">
+          <label class="form-group__label" for="signupPasswordConfirm">비밀번호 확인</label>
+          <input type="password" class="input" id="signupPasswordConfirm" placeholder="비밀번호 재입력" autocomplete="new-password" />
+          <p class="form-group__error" id="signupError"></p>
+        </div>
+        <div class="login-form__submit">
+          <button type="submit" class="btn btn--primary btn--full" id="signupBtn">회원가입</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <script type="module" src="../js/pages/login.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## 관련 이슈
Closes #2

## 변경 사항

### 새 파일
- `pages/login.html` — 로그인/회원가입 통합 페이지
- `css/pages/login.css` — 다크 네이비 배지 로고, 탭, 폼 스타일
- `js/pages/login.js` — 탭 전환, 유효성 검사, API 연동

### 기존 파일 수정
| 파일 | 수정 내용 |
|------|----------|
| `css/global.css` | `[hidden] { display: none !important; }` 추가 |
| `js/auth.js` | USER 리다이렉트 → `word-list.html` |
| `js/api.js` | `signup()`, `adminSignup()` nickname 파라미터 추가 |
| `js/utils.js` | `createEyeSvg()` hover 깜박이기 애니메이션 추가 |

## 이슈 대비 변경 사항
- 비밀번호 길이 제한 제거 (이슈엔 6자 이상 명시되어 있었으나 제거)
- 회원가입 폼에 닉네임 필드 추가 (백엔드 API 필수값)
- 유형 탭(학생/관리자)은 회원가입 탭에서만 표시 (로그인 탭엔 숨김)
- 로고: 다크 네이비 앱 아이콘 배지 + L👁👁kEng 인라인 디자인

## 테스트
- [x] 학생 로그인 → word-list.html 이동 확인
- [x] 관리자 로그인 → admin/word-manage.html 이동 확인
- [x] 이미 로그인 상태 → 자동 리다이렉트 확인
- [x] 로그인 탭: 유형 탭 숨김 확인
- [x] 회원가입 탭: 유형 탭 + 닉네임 필드 표시 확인
- [x] 로고 눈 hover → 깜박이기 + 마우스 추적 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)