### PR TITLE
🚧 feat: 단어장 및 테스트 페이지 (#3, #4)

### DIFF
--- a/css/pages/test.css
+++ b/css/pages/test.css
@@ -1,0 +1,349 @@
+/* ── 테스트 페이지 ── */
+
+/* topbar 레이아웃 */
+.topbar-layout {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  height: var(--topbar-height);
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 28px;
+  box-shadow: var(--shadow-sm);
+}
+
+.topbar__title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.topbar__right {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
+}
+
+.topbar-layout__main {
+  flex: 1;
+  padding: 40px 24px;
+  max-width: 680px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+/* ── 설정 화면 ── */
+.setup-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: 36px;
+  box-shadow: var(--shadow-card);
+}
+
+.setup-card__title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin-bottom: 28px;
+  color: var(--color-text-primary);
+}
+
+.setup-field {
+  margin-bottom: 28px;
+}
+
+.setup-field__label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+
+.setup-field__value {
+  font-size: 1.1rem;
+  font-weight: 800;
+  color: var(--color-blue-primary);
+}
+
+.slider {
+  width: 100%;
+  accent-color: var(--color-blue-primary);
+  cursor: pointer;
+}
+
+/* 퀴즈 타입 칩 */
+.chip-group {
+  display: flex;
+  gap: 10px;
+}
+
+.chip {
+  flex: 1;
+  padding: 10px 16px;
+  border-radius: var(--radius-sm);
+  border: 1.5px solid var(--color-border);
+  background: var(--color-surface);
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  text-align: center;
+}
+
+.chip:hover { border-color: var(--color-blue-primary); color: var(--color-blue-primary); }
+.chip--active {
+  border-color: var(--color-blue-primary);
+  background: rgba(91,127,219,0.08);
+  color: var(--color-blue-primary);
+}
+
+/* ── 진행 화면 ── */
+.quiz-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.quiz-progress-text {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+
+.quiz-progress-bar {
+  height: 6px;
+  background: var(--color-bg);
+  border-radius: 99px;
+  overflow: hidden;
+  margin-bottom: 28px;
+}
+
+.quiz-progress-bar__fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--color-blue-primary), var(--color-navy-light));
+  border-radius: 99px;
+  transition: width 0.3s ease;
+}
+
+/* 영단어 카드 */
+.quiz-word-card {
+  background: linear-gradient(145deg, var(--color-navy-light), var(--color-navy-dark));
+  border-radius: var(--radius-lg);
+  padding: 40px 32px;
+  text-align: center;
+  color: #fff;
+  min-height: 200px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin-bottom: 28px;
+  box-shadow: 0 8px 32px rgba(13,27,51,0.3);
+}
+
+.quiz-word-card__pos     { font-size: 0.85rem; color: rgba(255,255,255,0.5); font-family: var(--font-en); }
+.quiz-word-card__word    { font-size: 2.25rem; font-weight: 800; font-family: var(--font-en); line-height: 1.1; }
+.quiz-word-card__sentence { font-size: 0.875rem; color: rgba(255,255,255,0.55); font-style: italic; max-width: 480px; line-height: 1.5; }
+
+/* 주관식 입력 */
+.quiz-instruction {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
+  margin-bottom: 12px;
+  font-weight: 500;
+}
+
+.quiz-answer-row {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 24px;
+}
+
+.quiz-answer-row .input {
+  flex: 1;
+  padding: 12px 16px;
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: 1rem;
+  font-family: var(--font-ko);
+  outline: none;
+  transition: border-color var(--transition-fast);
+}
+.quiz-answer-row .input:focus { border-color: var(--color-border-focus); }
+
+/* 객관식 보기 */
+.quiz-choices {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.choice-btn {
+  padding: 18px 16px;
+  border-radius: var(--radius);
+  border: 2px solid var(--color-border);
+  background: var(--color-surface);
+  font-size: 0.95rem;
+  font-weight: 600;
+  font-family: var(--font-ko);
+  color: var(--color-text-primary);
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+  line-height: 1.4;
+}
+
+.choice-btn:hover:not(:disabled)  { border-color: var(--color-blue-primary); }
+.choice-btn.selected { border-color: var(--color-navy-dark); }
+.choice-btn.correct  { border-color: var(--color-success); background: var(--color-success-bg); color: var(--color-success); }
+.choice-btn.wrong    { border-color: var(--color-danger);  background: var(--color-danger-bg);  color: var(--color-danger); }
+.choice-btn:disabled { cursor: not-allowed; }
+
+/* 진행 도트 인디케이터 */
+.quiz-dots {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: center;
+  margin-top: 8px;
+}
+
+.quiz-dot {
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  border: 1.5px solid var(--color-border);
+  background: var(--color-surface);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  font-weight: 700;
+  transition: all 0.2s;
+}
+
+.quiz-dot--correct { background: var(--color-success-bg); color: var(--color-success); border-color: var(--color-success); }
+.quiz-dot--wrong   { background: var(--color-danger-bg);  color: var(--color-danger);  border-color: var(--color-danger); }
+.quiz-dot--current { border-color: var(--color-blue-primary); border-width: 2px; }
+
+/* ── 결과 화면 ── */
+.result-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: 40px 36px;
+  box-shadow: var(--shadow-card);
+  text-align: center;
+}
+
+.result-card__title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--color-text-secondary);
+  margin-bottom: 8px;
+}
+
+.result-card__accuracy {
+  font-size: 4rem;
+  font-weight: 800;
+  font-family: var(--font-en);
+  color: var(--color-blue-primary);
+  line-height: 1;
+  margin-bottom: 4px;
+}
+
+.result-card__summary {
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+  margin-bottom: 24px;
+}
+
+.result-stats {
+  display: flex;
+  justify-content: center;
+  gap: 32px;
+  margin-bottom: 32px;
+  flex-wrap: wrap;
+}
+
+.result-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.result-stat__label { font-size: 0.78rem; color: var(--color-text-muted); }
+.result-stat__value { font-size: 1.1rem; font-weight: 700; color: var(--color-text-primary); }
+
+/* 오답 목록 */
+.result-wrong-title {
+  font-size: 1rem;
+  font-weight: 700;
+  text-align: left;
+  margin-bottom: 12px;
+  color: var(--color-text-primary);
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+  text-align: left;
+}
+
+.data-table th {
+  padding: 10px 12px;
+  background: var(--color-bg);
+  color: var(--color-text-secondary);
+  font-weight: 600;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.data-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-text-primary);
+  vertical-align: middle;
+}
+
+.data-table td.en { font-family: var(--font-en); font-weight: 700; }
+.data-table td.wrong-answer { color: var(--color-danger); }
+.data-table td.correct-answer { color: var(--color-success); font-weight: 600; }
+
+.result-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  margin-top: 32px;
+  flex-wrap: wrap;
+}
+
+/* ── 테스트 기록 페이지 ── */
+.test-history-table-wrapper {
+  background: var(--color-surface);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 60px 20px;
+  color: var(--color-text-muted);
+}

--- a/css/pages/word-list.css
+++ b/css/pages/word-list.css
@@ -47,12 +47,26 @@
   justify-content: center;
 }
 
-.sidebar__brand-text {
+.sidebar__brand-logo {
+  display: flex;
+  align-items: center;
   font-family: var(--font-en);
   font-size: 1.1rem;
   font-weight: 800;
   color: #fff;
   letter-spacing: -0.3px;
+  gap: 1px;
+}
+
+.sidebar__brand-l,
+.sidebar__brand-keng {
+  line-height: 1;
+}
+
+.sidebar__brand-eye {
+  display: inline-flex;
+  align-items: center;
+  margin-top: 0.1em;
 }
 
 .sidebar__nav {
@@ -124,6 +138,14 @@
   font-size: 1.375rem;
   font-weight: 700;
   color: var(--color-text-primary);
+}
+
+.page-title__hint {
+  font-size: 0.75rem;
+  font-weight: 400;
+  color: var(--color-text-muted);
+  margin-left: 8px;
+  vertical-align: middle;
 }
 
 /* 진도 섹션 */
@@ -238,6 +260,7 @@
 .word-card__front {
   background: var(--color-surface);
   border: 1px solid var(--color-border);
+  padding-right: 44px;
 }
 
 .word-card__front-top {

--- a/css/pages/word-list.css
+++ b/css/pages/word-list.css
@@ -1,0 +1,392 @@
+/* ── 단어장 페이지 ── */
+
+/* 레이아웃 */
+.layout {
+  display: flex;
+  min-height: 100vh;
+}
+
+.layout__sidebar {
+  width: var(--sidebar-width);
+  flex-shrink: 0;
+  background: var(--color-navy-dark);
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.layout__main {
+  margin-left: var(--sidebar-width);
+  flex: 1;
+  padding: 32px;
+  min-height: 100vh;
+}
+
+/* 사이드바 스타일 */
+.sidebar__header {
+  padding: 24px 20px 16px;
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+}
+
+.sidebar__brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+}
+
+.sidebar__logo {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sidebar__brand-text {
+  font-family: var(--font-en);
+  font-size: 1.1rem;
+  font-weight: 800;
+  color: #fff;
+  letter-spacing: -0.3px;
+}
+
+.sidebar__nav {
+  flex: 1;
+  padding: 16px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  color: rgba(255,255,255,0.6);
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.nav-item:hover { background: rgba(255,255,255,0.07); color: #fff; }
+.nav-item--active { background: rgba(91,127,219,0.25); color: #fff; font-weight: 700; }
+
+.nav-item__icon { width: 18px; height: 18px; flex-shrink: 0; }
+
+.sidebar__footer {
+  padding: 16px 20px;
+  border-top: 1px solid rgba(255,255,255,0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sidebar__user-label { font-size: 0.72rem; color: rgba(255,255,255,0.4); }
+.sidebar__user-name  { font-size: 0.875rem; color: #fff; font-weight: 600; }
+
+.sidebar__logout-btn {
+  margin-top: 8px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 10px;
+  border-radius: var(--radius-sm);
+  background: rgba(239,68,68,0.12);
+  color: rgba(239,68,68,0.85);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  border: none;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  width: 100%;
+}
+.sidebar__logout-btn:hover { background: rgba(239,68,68,0.22); }
+
+/* 헤더 */
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.page-title {
+  font-size: 1.375rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+/* 진도 섹션 */
+.progress-section {
+  background: var(--color-surface);
+  border-radius: var(--radius);
+  padding: 20px 24px;
+  margin-bottom: 24px;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.progress-section__label {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+}
+
+.progress-bar {
+  flex: 1;
+  min-width: 160px;
+  height: 8px;
+  background: var(--color-bg);
+  border-radius: 99px;
+  overflow: hidden;
+}
+
+.progress-bar__fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--color-blue-primary), var(--color-navy-light));
+  border-radius: 99px;
+  transition: width 0.4s ease;
+}
+
+.progress-section__count {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  white-space: nowrap;
+}
+
+/* 컨트롤 바 */
+.controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.sort-select {
+  padding: 8px 12px;
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: 0.875rem;
+  font-family: var(--font-ko);
+  color: var(--color-text-primary);
+  background: var(--color-surface);
+  cursor: pointer;
+  outline: none;
+}
+.sort-select:focus { border-color: var(--color-border-focus); }
+
+/* 단어 카드 그리드 */
+.word-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 20px;
+  margin-bottom: 32px;
+}
+
+/* 3D 플립 카드 */
+.word-card-wrapper {
+  position: relative;
+  height: 180px;
+  perspective: 1000px;
+  cursor: pointer;
+}
+
+.word-card {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  transform-style: preserve-3d;
+  transition: transform var(--transition-flip);
+  border-radius: var(--radius);
+}
+
+.word-card-wrapper:hover .word-card:not(.is-flipped) {
+  transform: rotateY(5deg);
+}
+
+.word-card.is-flipped { transform: rotateY(180deg); }
+
+.word-card__face {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+  border-radius: var(--radius);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  box-shadow: var(--shadow-card);
+}
+
+/* 앞면 */
+.word-card__front {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+}
+
+.word-card__front-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.word-card__english {
+  font-family: var(--font-en);
+  font-size: 1.35rem;
+  font-weight: 800;
+  color: var(--color-navy-dark);
+  line-height: 1.2;
+  word-break: break-word;
+}
+
+.word-card__sentence {
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+  font-style: italic;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.word-card__flip-hint {
+  font-size: 0.72rem;
+  color: var(--color-text-muted);
+  text-align: right;
+}
+
+/* 뒷면 */
+.word-card__back {
+  background: linear-gradient(145deg, var(--color-navy-light), var(--color-navy-dark));
+  transform: rotateY(180deg);
+  align-items: center;
+  justify-content: center;
+}
+
+.word-card__meaning {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #fff;
+  text-align: center;
+  line-height: 1.4;
+}
+
+/* 암기완료 버튼 */
+.memorize-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 10;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 1.5px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
+  cursor: pointer;
+}
+
+.memorize-btn:hover {
+  background: var(--color-success-bg);
+  border-color: var(--color-success);
+  color: var(--color-success);
+}
+
+/* 암기완료 상태 */
+.word-card-wrapper--memorized .word-card__front {
+  background: var(--color-bg);
+  opacity: 0.7;
+}
+
+.word-card-wrapper--memorized .word-card__english {
+  color: var(--color-memorized);
+  text-decoration: line-through;
+}
+
+.word-card-wrapper--memorized .memorize-btn {
+  background: var(--color-success-bg);
+  border-color: var(--color-success);
+  color: var(--color-success);
+}
+
+/* 품사 배지 */
+.pos-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 99px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  font-family: var(--font-en);
+  text-transform: lowercase;
+  flex-shrink: 0;
+}
+
+.pos-badge--noun      { background: #EEF2FF; color: #4338CA; }
+.pos-badge--verb      { background: #F0FDF4; color: #15803D; }
+.pos-badge--adjective { background: #FFF7ED; color: #C2410C; }
+.pos-badge--adverb    { background: #FDF4FF; color: #7E22CE; }
+.pos-badge--default   { background: var(--color-bg); color: var(--color-text-muted); }
+
+/* 페이지네이션 */
+.pagination-wrapper { display: flex; justify-content: center; margin-top: 8px; }
+
+.pagination { display: flex; gap: 6px; }
+
+.pagination__btn {
+  min-width: 36px;
+  height: 36px;
+  padding: 0 10px;
+  border-radius: var(--radius-sm);
+  border: 1.5px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.pagination__btn:hover:not(:disabled) {
+  border-color: var(--color-blue-primary);
+  color: var(--color-blue-primary);
+}
+
+.pagination__btn--active {
+  background: var(--color-blue-primary);
+  border-color: var(--color-blue-primary);
+  color: #fff;
+}
+
+.pagination__btn:disabled { opacity: 0.35; cursor: not-allowed; }
+
+/* 빈 상태 */
+.empty-state {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 60px 20px;
+  color: var(--color-text-muted);
+}

--- a/js/pages/test-history.js
+++ b/js/pages/test-history.js
@@ -1,0 +1,55 @@
+import { TestApi } from '../api.js';
+import { auth } from '../auth.js';
+import { showToast, buildSidebar, renderPagination, formatDate, formatDuration } from '../utils.js';
+
+auth.requireLogin();
+buildSidebar('test');
+
+const PAGE_SIZE = 10;
+
+async function loadHistory(page = 0) {
+  try {
+    const res = await TestApi.getHistory(page, PAGE_SIZE);
+    if (!res || !res.success) {
+      showToast(res?.message || '기록을 불러오지 못했습니다.', 'error');
+      return;
+    }
+
+    const { content, totalPages } = res.data;
+    renderTable(content);
+    renderPagination(
+      document.getElementById('pagination'),
+      page,
+      totalPages,
+      loadHistory
+    );
+  } catch {
+    showToast('네트워크 오류가 발생했습니다.', 'error');
+  }
+}
+
+function renderTable(records) {
+  const tbody = document.getElementById('historyBody');
+
+  if (!records || records.length === 0) {
+    tbody.innerHTML = `
+      <tr>
+        <td colspan="5" class="empty-state">아직 테스트 기록이 없습니다.</td>
+      </tr>`;
+    return;
+  }
+
+  const quizTypeLabel = { SHORT_ANSWER: '주관식', MULTIPLE_CHOICE: '객관식' };
+
+  tbody.innerHTML = records.map(r => `
+    <tr>
+      <td>${formatDate(r.finishedAt)}</td>
+      <td>${quizTypeLabel[r.quizType] ?? r.quizType}</td>
+      <td>${r.totalCount}문제</td>
+      <td><strong>${r.accuracy}%</strong></td>
+      <td>${formatDuration(r.durationSec)}</td>
+    </tr>
+  `).join('');
+}
+
+loadHistory(0);

--- a/js/pages/test.js
+++ b/js/pages/test.js
@@ -1,0 +1,288 @@
+import { TestApi } from '../api.js';
+import { auth } from '../auth.js';
+import { showToast, formatDuration } from '../utils.js';
+
+auth.requireLogin();
+
+// ── 오늘 날짜 표시 ────────────────────────────────────────────
+(function setDate() {
+  const d = new Date();
+  const month = d.getMonth() + 1;
+  const day = d.getDate();
+  const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
+  document.getElementById('todayDate').textContent =
+    `${month}월 ${day}일 (${weekdays[d.getDay()]})`;
+})();
+
+// ── 로그아웃 ─────────────────────────────────────────────────
+import { AuthApi } from '../api.js';
+document.getElementById('logoutBtn').addEventListener('click', async () => {
+  try { await AuthApi.logout(); } catch (_) {}
+  auth.clearSession();
+  location.replace('./login.html');
+});
+
+// ── 상태 ─────────────────────────────────────────────────────
+let sessionId      = null;
+let totalCount     = 10;
+let quizType       = 'SHORT_ANSWER';
+let currentIndex   = 0;
+let currentQuestion = null;
+let startTime      = null;
+
+// ── 화면 전환 ─────────────────────────────────────────────────
+function showView(id) {
+  ['setupView', 'quizView', 'resultView'].forEach(v => {
+    document.getElementById(v).hidden = v !== id;
+  });
+}
+
+// ── 설정 화면 ─────────────────────────────────────────────────
+const slider      = document.getElementById('totalCountSlider');
+const countDisplay = document.getElementById('totalCountDisplay');
+
+slider.addEventListener('input', () => {
+  totalCount = Number(slider.value);
+  countDisplay.textContent = totalCount;
+});
+
+document.querySelectorAll('.chip').forEach(chip => {
+  chip.addEventListener('click', () => {
+    document.querySelectorAll('.chip').forEach(c => c.classList.remove('chip--active'));
+    chip.classList.add('chip--active');
+    quizType = chip.dataset.type;
+  });
+});
+
+document.getElementById('startBtn').addEventListener('click', startTest);
+
+async function startTest() {
+  const btn = document.getElementById('startBtn');
+  btn.disabled = true;
+  btn.textContent = '불러오는 중...';
+
+  try {
+    const res = await TestApi.start(totalCount, quizType);
+    if (!res || !res.success) {
+      showToast(res?.message || '테스트를 시작할 수 없습니다.', 'error');
+      return;
+    }
+
+    sessionId      = res.data.sessionId;
+    totalCount     = res.data.totalCount;
+    currentIndex   = 0;
+    startTime      = Date.now();
+
+    initDots(totalCount);
+    showView('quizView');
+    renderQuestion(res.data.currentQuestion);
+  } catch {
+    showToast('네트워크 오류가 발생했습니다.', 'error');
+  } finally {
+    btn.disabled = false;
+    btn.textContent = '시작하기';
+  }
+}
+
+// ── 문제 렌더링 ───────────────────────────────────────────────
+function renderQuestion(question) {
+  currentQuestion = question;
+
+  document.getElementById('qPos').textContent      = question.pronunciation || '';
+  document.getElementById('qWord').textContent     = question.english;
+  document.getElementById('qSentence').textContent = question.exampleSentence || '';
+
+  const progressPct = Math.round((currentIndex / totalCount) * 100);
+  document.getElementById('progressText').textContent = `${currentIndex + 1} / ${totalCount}`;
+  document.getElementById('progressFill').style.width = `${progressPct}%`;
+
+  if (quizType === 'SHORT_ANSWER') {
+    document.getElementById('shortAnswerArea').hidden    = false;
+    document.getElementById('multipleChoiceArea').hidden = true;
+    const input = document.getElementById('answerInput');
+    input.value = '';
+    input.disabled = false;
+    input.focus();
+    const confirmBtn = document.getElementById('confirmBtn');
+    confirmBtn.disabled = false;
+    confirmBtn.textContent = '확인';
+  } else {
+    document.getElementById('shortAnswerArea').hidden    = true;
+    document.getElementById('multipleChoiceArea').hidden = false;
+    renderChoices(question);
+  }
+}
+
+// ── 주관식 제출 ───────────────────────────────────────────────
+document.getElementById('confirmBtn').addEventListener('click', () => {
+  const val = document.getElementById('answerInput').value.trim();
+  if (!val) return;
+  submitAnswer(val);
+});
+
+document.getElementById('answerInput').addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') {
+    const val = document.getElementById('answerInput').value.trim();
+    if (!val) return;
+    submitAnswer(val);
+  }
+});
+
+// ── 객관식 렌더링 ─────────────────────────────────────────────
+function renderChoices(question) {
+  const grid = document.getElementById('choicesGrid');
+  // 백엔드에서 보기(choices)를 내려준다면 사용, 없으면 meaning만 정답으로
+  const choices = question.choices || [question.meaning];
+  grid.innerHTML = choices.map((choice, i) =>
+    `<button class="choice-btn" data-index="${i}">${escapeHtml(choice)}</button>`
+  ).join('');
+
+  grid.querySelectorAll('.choice-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      grid.querySelectorAll('.choice-btn').forEach(b => b.disabled = true);
+      btn.classList.add('selected');
+      submitAnswer(btn.textContent);
+    });
+  });
+}
+
+// ── 답안 제출 공통 ────────────────────────────────────────────
+async function submitAnswer(userAnswer) {
+  const confirmBtn = document.getElementById('confirmBtn');
+  if (confirmBtn) confirmBtn.disabled = true;
+
+  const input = document.getElementById('answerInput');
+  if (input) input.disabled = true;
+
+  try {
+    const res = await TestApi.submitAnswer(sessionId, currentQuestion.wordId, userAnswer);
+    if (!res || !res.success) {
+      showToast(res?.message || '오류가 발생했습니다.', 'error');
+      if (confirmBtn) confirmBtn.disabled = false;
+      if (input) input.disabled = false;
+      return;
+    }
+
+    const { isCorrect, isFinished, currentQuestion: nextQuestion } = res.data;
+
+    showFeedback(isCorrect);
+    updateDot(currentIndex, isCorrect);
+
+    setTimeout(async () => {
+      if (isFinished) {
+        await finishTest();
+      } else {
+        currentIndex++;
+        renderQuestion(nextQuestion);
+      }
+    }, 800);
+  } catch {
+    showToast('네트워크 오류가 발생했습니다.', 'error');
+    if (confirmBtn) confirmBtn.disabled = false;
+    if (input) input.disabled = false;
+  }
+}
+
+// ── 정/오답 피드백 ────────────────────────────────────────────
+function showFeedback(isCorrect) {
+  if (quizType === 'MULTIPLE_CHOICE') {
+    const grid = document.getElementById('choicesGrid');
+    grid.querySelectorAll('.choice-btn.selected').forEach(btn => {
+      btn.classList.add(isCorrect ? 'correct' : 'wrong');
+    });
+  }
+  // 주관식은 배경색 토글
+  const input = document.getElementById('answerInput');
+  if (input) {
+    input.style.borderColor = isCorrect ? 'var(--color-success)' : 'var(--color-danger)';
+    setTimeout(() => { input.style.borderColor = ''; }, 700);
+  }
+}
+
+// ── 도트 인디케이터 ───────────────────────────────────────────
+function initDots(count) {
+  const container = document.getElementById('quizDots');
+  container.innerHTML = Array.from({ length: count }, (_, i) =>
+    `<div class="quiz-dot ${i === 0 ? 'quiz-dot--current' : ''}" id="dot-${i}"></div>`
+  ).join('');
+}
+
+function updateDot(index, isCorrect) {
+  const dot = document.getElementById(`dot-${index}`);
+  if (!dot) return;
+  dot.classList.remove('quiz-dot--current');
+  dot.classList.add(isCorrect ? 'quiz-dot--correct' : 'quiz-dot--wrong');
+  dot.textContent = isCorrect ? '✓' : '✗';
+
+  const next = document.getElementById(`dot-${index + 1}`);
+  if (next) next.classList.add('quiz-dot--current');
+}
+
+// ── 테스트 종료 ───────────────────────────────────────────────
+async function finishTest() {
+  const elapsed = Math.floor((Date.now() - startTime) / 1000);
+
+  try {
+    const res = await TestApi.finish(sessionId, elapsed);
+    if (!res || !res.success) {
+      showToast(res?.message || '결과를 불러오지 못했습니다.', 'error');
+      return;
+    }
+    renderResult(res.data);
+    showView('resultView');
+  } catch {
+    showToast('네트워크 오류가 발생했습니다.', 'error');
+  }
+}
+
+function renderResult(data) {
+  const { totalCount: total, correctCount, accuracy, durationSec, wrongAnswers } = data;
+
+  document.getElementById('resultAccuracy').textContent = `${accuracy}%`;
+  document.getElementById('resultSummary').textContent  = `${total}문제 중 ${correctCount}개 정답`;
+  document.getElementById('resultCorrect').textContent  = `${correctCount} / ${total}`;
+  document.getElementById('resultDuration').textContent = formatDuration(durationSec);
+
+  const wrongSection = document.getElementById('wrongAnswerSection');
+  if (wrongAnswers && wrongAnswers.length > 0) {
+    wrongSection.hidden = false;
+    document.getElementById('wrongAnswerBody').innerHTML = wrongAnswers.map(w =>
+      `<tr>
+        <td class="en">${escapeHtml(w.english)}</td>
+        <td class="wrong-answer">${escapeHtml(w.userAnswer ?? '-')}</td>
+        <td class="correct-answer">${escapeHtml(w.correctAnswer ?? w.meaning ?? '-')}</td>
+      </tr>`
+    ).join('');
+  } else {
+    wrongSection.hidden = true;
+  }
+}
+
+// ── 그만하기 버튼 ─────────────────────────────────────────────
+document.getElementById('quitBtn').addEventListener('click', () => {
+  if (confirm('테스트를 그만하시겠습니까? 진행 기록은 저장되지 않습니다.')) {
+    resetSetup();
+    showView('setupView');
+  }
+});
+
+// ── 다시 시작 ─────────────────────────────────────────────────
+document.getElementById('retryBtn').addEventListener('click', () => {
+  resetSetup();
+  showView('setupView');
+});
+
+function resetSetup() {
+  sessionId    = null;
+  currentIndex = 0;
+  startTime    = null;
+}
+
+// ── 유틸 ─────────────────────────────────────────────────────
+function escapeHtml(str) {
+  return String(str ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/js/pages/word-list.js
+++ b/js/pages/word-list.js
@@ -1,0 +1,149 @@
+import { WordApi } from '../api.js';
+import { auth } from '../auth.js';
+import { showToast, buildSidebar, renderPagination, getPosClass } from '../utils.js';
+
+auth.requireLogin();
+buildSidebar('word-list');
+
+// ADMIN이면 단어 추가 버튼 노출
+if (auth.isAdmin()) {
+  document.getElementById('addWordBtn').hidden = false;
+}
+
+// ── 상태 ─────────────────────────────────────────────────────
+const PAGE_SIZE = 20;
+let currentPage = 0;
+let currentSort = 'id,asc';
+let totalElements = 0;
+
+// ── 진도 바 ──────────────────────────────────────────────────
+function getMemorizedCount() {
+  return Object.keys(localStorage).filter(k => k.startsWith('memorized_')).length;
+}
+
+function updateProgress() {
+  const memorized = getMemorizedCount();
+  const pct = totalElements > 0 ? Math.round((memorized / totalElements) * 100) : 0;
+  document.getElementById('progressFill').style.width = `${pct}%`;
+  document.getElementById('progressCount').textContent = `암기완료 ${memorized} / ${totalElements}`;
+}
+
+// ── 단어 로드 ─────────────────────────────────────────────────
+async function loadWords(page = 0, sort = currentSort) {
+  currentPage = page;
+  currentSort = sort;
+
+  try {
+    const res = await WordApi.getList(page, PAGE_SIZE, sort);
+    if (!res || !res.success) {
+      showToast(res?.message || '단어 목록을 불러오지 못했습니다.', 'error');
+      return;
+    }
+
+    const { content, totalElements: total, totalPages } = res.data;
+    totalElements = total;
+
+    document.getElementById('totalCount').textContent = `총 ${total}개`;
+    renderWordGrid(content);
+    updateProgress();
+    renderPagination(
+      document.getElementById('pagination'),
+      page,
+      totalPages,
+      (p) => loadWords(p, currentSort)
+    );
+  } catch {
+    showToast('네트워크 오류가 발생했습니다.', 'error');
+  }
+}
+
+// ── 카드 렌더링 ───────────────────────────────────────────────
+function renderWordGrid(words) {
+  const grid = document.getElementById('wordGrid');
+
+  if (words.length === 0) {
+    grid.innerHTML = '<div class="empty-state">등록된 단어가 없습니다.</div>';
+    return;
+  }
+
+  grid.innerHTML = words.map(buildWordCard).join('');
+}
+
+function buildWordCard(word) {
+  const posClass = getPosClass(word.pronunciation);
+  const posLabel = word.pronunciation || '';
+  const memorized = localStorage.getItem(`memorized_${word.id}`) === '1';
+  const memorizedClass = memorized ? 'word-card-wrapper--memorized' : '';
+  const sentence = word.exampleSentence ? escapeHtml(word.exampleSentence) : '';
+
+  return `
+    <div class="word-card-wrapper ${memorizedClass}" data-word-id="${word.id}">
+      <div class="word-card">
+        <div class="word-card__face word-card__front">
+          <div class="word-card__front-top">
+            <h2 class="word-card__english en">${escapeHtml(word.english)}</h2>
+            ${posLabel ? `<span class="pos-badge ${posClass}">${escapeHtml(posLabel)}</span>` : ''}
+          </div>
+          <p class="word-card__sentence">${sentence}</p>
+          <span class="word-card__flip-hint">클릭하여 뜻 보기 →</span>
+        </div>
+        <div class="word-card__face word-card__back">
+          <p class="word-card__meaning">${escapeHtml(word.meaning)}</p>
+        </div>
+      </div>
+      <button class="memorize-btn" data-word-id="${word.id}" title="암기완료 토글">✓</button>
+    </div>
+  `;
+}
+
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+// ── 이벤트 위임 — 카드 클릭 & 암기완료 버튼 ──────────────────
+document.getElementById('wordGrid').addEventListener('click', (e) => {
+  // 암기완료 버튼 클릭 → 플립 없이 상태만 토글
+  const memorizeBtn = e.target.closest('.memorize-btn');
+  if (memorizeBtn) {
+    e.stopPropagation();
+    toggleMemorized(memorizeBtn.dataset.wordId);
+    return;
+  }
+
+  // 카드 클릭 → 플립
+  const wrapper = e.target.closest('.word-card-wrapper');
+  if (wrapper) {
+    const card = wrapper.querySelector('.word-card');
+    card.classList.toggle('is-flipped');
+  }
+});
+
+function toggleMemorized(wordId) {
+  const key = `memorized_${wordId}`;
+  const isMemorized = localStorage.getItem(key) === '1';
+
+  if (isMemorized) {
+    localStorage.removeItem(key);
+  } else {
+    localStorage.setItem(key, '1');
+  }
+
+  const wrapper = document.querySelector(`[data-word-id="${wordId}"].word-card-wrapper`);
+  if (wrapper) {
+    wrapper.classList.toggle('word-card-wrapper--memorized', !isMemorized);
+  }
+
+  updateProgress();
+}
+
+// ── 정렬 셀렉터 ───────────────────────────────────────────────
+document.getElementById('sortSelect').addEventListener('change', (e) => {
+  loadWords(0, e.target.value);
+});
+
+// ── 초기 로드 ─────────────────────────────────────────────────
+loadWords(0);

--- a/js/pages/word-list.js
+++ b/js/pages/word-list.js
@@ -13,7 +13,7 @@ if (auth.isAdmin()) {
 // ── 상태 ─────────────────────────────────────────────────────
 const PAGE_SIZE = 20;
 let currentPage = 0;
-let currentSort = 'id,asc';
+let currentSort = 'english,asc';
 let totalElements = 0;
 
 // ── 진도 바 ──────────────────────────────────────────────────
@@ -70,8 +70,8 @@ function renderWordGrid(words) {
 }
 
 function buildWordCard(word) {
-  const posClass = getPosClass(word.pronunciation);
-  const posLabel = word.pronunciation || '';
+  const posClass = getPosClass(word.partOfSpeech);
+  const posLabel = word.partOfSpeech || '';
   const memorized = localStorage.getItem(`memorized_${word.id}`) === '1';
   const memorizedClass = memorized ? 'word-card-wrapper--memorized' : '';
   const sentence = word.exampleSentence ? escapeHtml(word.exampleSentence) : '';
@@ -85,10 +85,9 @@ function buildWordCard(word) {
             ${posLabel ? `<span class="pos-badge ${posClass}">${escapeHtml(posLabel)}</span>` : ''}
           </div>
           <p class="word-card__sentence">${sentence}</p>
-          <span class="word-card__flip-hint">클릭하여 뜻 보기 →</span>
         </div>
         <div class="word-card__face word-card__back">
-          <p class="word-card__meaning">${escapeHtml(word.meaning)}</p>
+          <p class="word-card__meaning">${escapeHtml(word.korean)}</p>
         </div>
       </div>
       <button class="memorize-btn" data-word-id="${word.id}" title="암기완료 토글">✓</button>

--- a/js/utils.js
+++ b/js/utils.js
@@ -267,8 +267,12 @@ export function buildSidebar(activeMenu) {
   sidebar.innerHTML = `
     <div class="sidebar__header">
       <a href="${prefix}dashboard.html" class="sidebar__brand">
-        <div class="sidebar__logo" id="sidebarLogoEyes"></div>
-        <span class="sidebar__brand-text">LookEng</span>
+        <div class="sidebar__brand-logo">
+          <span class="sidebar__brand-l">L</span>
+          <span class="sidebar__brand-eye" id="sidebarLogoEye1"></span>
+          <span class="sidebar__brand-eye" id="sidebarLogoEye2"></span>
+          <span class="sidebar__brand-keng">kEng</span>
+        </div>
       </a>
     </div>
     <nav class="sidebar__nav">${navHTML}</nav>
@@ -284,12 +288,11 @@ export function buildSidebar(activeMenu) {
     </div>
   `;
 
-  // 사이드바 로고 눈 렌더링 (작은 크기)
-  const logoContainer = document.getElementById('sidebarLogoEyes');
-  if (logoContainer) {
-    const eye = createEyeSvg(0.38);
-    logoContainer.appendChild(eye);
-  }
+  // 사이드바 로고 눈 렌더링 (작은 크기, 2개)
+  const eye1 = document.getElementById('sidebarLogoEye1');
+  const eye2 = document.getElementById('sidebarLogoEye2');
+  if (eye1) eye1.appendChild(createEyeSvg(0.38));
+  if (eye2) eye2.appendChild(createEyeSvg(0.38));
 
   // 로그아웃 이벤트
   document.getElementById('logoutBtn')?.addEventListener('click', async () => {

--- a/pages/test-history.html
+++ b/pages/test-history.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>LookEng — 테스트 기록</title>
+  <link rel="stylesheet" href="../css/global.css" />
+  <link rel="stylesheet" href="../css/components.css" />
+  <link rel="stylesheet" href="../css/pages/word-list.css" />
+  <link rel="stylesheet" href="../css/pages/test.css" />
+</head>
+<body>
+  <div class="layout">
+    <div class="layout__sidebar" id="sidebar"></div>
+
+    <main class="layout__main">
+      <div class="page-header">
+        <h1 class="page-title">테스트 기록</h1>
+      </div>
+
+      <div class="test-history-table-wrapper">
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th>날짜</th>
+              <th>유형</th>
+              <th>문제 수</th>
+              <th>정답률</th>
+              <th>소요 시간</th>
+            </tr>
+          </thead>
+          <tbody id="historyBody"></tbody>
+        </table>
+      </div>
+
+      <div class="pagination-wrapper" id="pagination"></div>
+    </main>
+  </div>
+
+  <script type="module" src="../js/pages/test-history.js"></script>
+</body>
+</html>

--- a/pages/test.html
+++ b/pages/test.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>LookEng — 테스트</title>
+  <link rel="stylesheet" href="../css/global.css" />
+  <link rel="stylesheet" href="../css/components.css" />
+  <link rel="stylesheet" href="../css/pages/test.css" />
+</head>
+<body>
+  <div class="topbar-layout">
+    <header class="topbar">
+      <span class="topbar__title">단어 퀴즈</span>
+      <div class="topbar__right">
+        <span id="todayDate"></span>
+        <button class="btn btn--ghost btn--sm" id="logoutBtn">로그아웃</button>
+      </div>
+    </header>
+
+    <main class="topbar-layout__main">
+
+      <!-- 설정 화면 -->
+      <section id="setupView">
+        <div class="setup-card">
+          <h2 class="setup-card__title">퀴즈 설정</h2>
+
+          <div class="setup-field">
+            <div class="setup-field__label">
+              <span>문제 수</span>
+              <span class="setup-field__value" id="totalCountDisplay">10</span>
+            </div>
+            <input type="range" class="slider" id="totalCountSlider"
+                   min="5" max="30" value="10" step="5" />
+          </div>
+
+          <div class="setup-field">
+            <div class="setup-field__label">
+              <span>퀴즈 유형</span>
+            </div>
+            <div class="chip-group">
+              <button class="chip chip--active" data-type="SHORT_ANSWER">주관식</button>
+              <button class="chip" data-type="MULTIPLE_CHOICE">객관식</button>
+            </div>
+          </div>
+
+          <button class="btn btn--primary btn--full" id="startBtn" style="margin-top:8px">시작하기</button>
+        </div>
+      </section>
+
+      <!-- 진행 화면 -->
+      <section id="quizView" hidden>
+        <div class="quiz-header">
+          <button class="btn btn--ghost btn--sm" id="quitBtn">그만하기</button>
+          <span class="quiz-progress-text" id="progressText">1 / 10</span>
+        </div>
+        <div class="quiz-progress-bar">
+          <div class="quiz-progress-bar__fill" id="progressFill" style="width: 0%"></div>
+        </div>
+
+        <!-- 영단어 카드 -->
+        <div class="quiz-word-card">
+          <span class="quiz-word-card__pos" id="qPos"></span>
+          <h2 class="quiz-word-card__word en" id="qWord"></h2>
+          <p class="quiz-word-card__sentence" id="qSentence"></p>
+        </div>
+
+        <!-- 주관식 입력 -->
+        <div id="shortAnswerArea">
+          <p class="quiz-instruction">영단어의 한글 뜻을 입력하세요</p>
+          <div class="quiz-answer-row">
+            <input type="text" class="input" id="answerInput"
+                   placeholder="예: 포기하다, 버리다" autocomplete="off" />
+            <button class="btn btn--primary" id="confirmBtn">확인</button>
+          </div>
+        </div>
+
+        <!-- 객관식 보기 -->
+        <div id="multipleChoiceArea" hidden>
+          <p class="quiz-instruction">뜻으로 알맞은 것을 고르세요</p>
+          <div class="quiz-choices" id="choicesGrid"></div>
+        </div>
+
+        <!-- 하단 도트 인디케이터 -->
+        <div class="quiz-dots" id="quizDots"></div>
+      </section>
+
+      <!-- 결과 화면 -->
+      <section id="resultView" hidden>
+        <div class="result-card">
+          <p class="result-card__title">퀴즈 결과</p>
+          <div class="result-card__accuracy" id="resultAccuracy">0%</div>
+          <p class="result-card__summary" id="resultSummary"></p>
+
+          <div class="result-stats">
+            <div class="result-stat">
+              <span class="result-stat__label">맞은 문제</span>
+              <span class="result-stat__value" id="resultCorrect">-</span>
+            </div>
+            <div class="result-stat">
+              <span class="result-stat__label">소요 시간</span>
+              <span class="result-stat__value" id="resultDuration">-</span>
+            </div>
+          </div>
+
+          <div id="wrongAnswerSection" hidden>
+            <p class="result-wrong-title">오답 목록</p>
+            <table class="data-table">
+              <thead>
+                <tr>
+                  <th>영단어</th>
+                  <th>내 답</th>
+                  <th>정답</th>
+                </tr>
+              </thead>
+              <tbody id="wrongAnswerBody"></tbody>
+            </table>
+          </div>
+
+          <div class="result-actions">
+            <button class="btn btn--ghost" id="retryBtn">다시 시작</button>
+            <a href="./word-list.html" class="btn btn--primary">단어장으로</a>
+          </div>
+        </div>
+      </section>
+
+    </main>
+  </div>
+
+  <script type="module" src="../js/pages/test.js"></script>
+</body>
+</html>

--- a/pages/word-list.html
+++ b/pages/word-list.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>LookEng — 단어장</title>
+  <link rel="stylesheet" href="../css/global.css" />
+  <link rel="stylesheet" href="../css/components.css" />
+  <link rel="stylesheet" href="../css/pages/word-list.css" />
+</head>
+<body>
+  <div class="layout">
+    <div class="layout__sidebar" id="sidebar"></div>
+
+    <main class="layout__main">
+      <!-- 헤더 -->
+      <div class="page-header">
+        <h1 class="page-title">단어장</h1>
+        <button class="btn btn--primary" id="addWordBtn" hidden>+ 새 단어 추가</button>
+      </div>
+
+      <!-- 학습 진도 바 -->
+      <div class="progress-section">
+        <span class="progress-section__label">학습 진도</span>
+        <div class="progress-bar">
+          <div class="progress-bar__fill" id="progressFill" style="width: 0%"></div>
+        </div>
+        <span class="progress-section__count" id="progressCount">암기완료 0 / 0</span>
+      </div>
+
+      <!-- 컨트롤 바 -->
+      <div class="controls">
+        <span id="totalCount" style="font-size:0.875rem;color:var(--color-text-secondary)"></span>
+        <select class="sort-select" id="sortSelect">
+          <option value="id,asc">기본순</option>
+          <option value="english,asc">알파벳 ↑</option>
+          <option value="english,desc">알파벳 ↓</option>
+        </select>
+      </div>
+
+      <!-- 단어 카드 그리드 -->
+      <div class="word-grid" id="wordGrid"></div>
+
+      <!-- 페이지네이션 -->
+      <div class="pagination-wrapper" id="pagination"></div>
+    </main>
+  </div>
+
+  <script type="module" src="../js/pages/word-list.js"></script>
+</body>
+</html>

--- a/pages/word-list.html
+++ b/pages/word-list.html
@@ -15,7 +15,7 @@
     <main class="layout__main">
       <!-- 헤더 -->
       <div class="page-header">
-        <h1 class="page-title">단어장</h1>
+        <h1 class="page-title">단어장 <span class="page-title__hint">카드를 클릭하면 뜻을 볼 수 있어요</span></h1>
         <button class="btn btn--primary" id="addWordBtn" hidden>+ 새 단어 추가</button>
       </div>
 
@@ -32,9 +32,8 @@
       <div class="controls">
         <span id="totalCount" style="font-size:0.875rem;color:var(--color-text-secondary)"></span>
         <select class="sort-select" id="sortSelect">
-          <option value="id,asc">기본순</option>
-          <option value="english,asc">알파벳 ↑</option>
-          <option value="english,desc">알파벳 ↓</option>
+          <option value="english,asc">A → Z</option>
+          <option value="english,desc">Z → A</option>
         </select>
       </div>
 


### PR DESCRIPTION
## 관련 이슈
Closes #3

## 현재 상태
> **🚧 작업 중 (WIP)** — 아직 수정이 필요한 상태입니다. 완료 후 Ready for review로 전환 예정.

## 포함 파일

### 이슈 #3 — 단어장
- `pages/word-list.html`
- `css/pages/word-list.css`
- `js/pages/word-list.js`

### 이슈 #4 — 테스트의 일부분!!!
- `pages/test.html`
- `pages/test-history.html`
- `css/pages/test.css`
- `js/pages/test.js`
- `js/pages/test-history.js`

## 테스트 (완료 후 체크 예정)
- [ ] 카드 클릭 → 3D 플립
- [ ] 암기완료 버튼 → 카드 흐리게 + 진도바 업데이트
- [ ] 정렬 변경 → 목록 재로드
- [ ] 테스트 설정 → 진행 → 결과 화면 전환
- [ ] 주관식 / 객관식 동작에서 주관식은 MVP라 정상 작동, 객관식은 버튼 형식만 남겨두기!
- [ ] 도트 인디케이터 정/오답 표시
- [ ] 기록 조회 테이블 + 페이지네이션

🤖 Generated with [Claude Code](https://claude.com/claude-code)