### PR TITLE
✨ feat: 테스트 설정/진행/결과/기록 페이지 (#4)

### DIFF
--- a/css/pages/test.css
+++ b/css/pages/test.css
@@ -43,6 +43,23 @@
   width: 100%;
 }
 
+/* ── 테스트 페이지 콘텐츠 중앙 정렬 ── */
+#setupView,
+#quizView,
+#resultView {
+  max-width: 900px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+/* ── 설정 화면 레이아웃 ── */
+.setup-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  align-items: start;
+}
+
 /* ── 설정 화면 ── */
 .setup-card {
   background: var(--color-surface);
@@ -70,6 +87,12 @@
   font-size: 0.9rem;
   font-weight: 600;
   color: var(--color-text-secondary);
+}
+
+.setup-field__hint {
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+  margin-top: 8px;
 }
 
 .setup-field__value {
@@ -109,6 +132,134 @@
   border-color: var(--color-blue-primary);
   background: rgba(91,127,219,0.08);
   color: var(--color-blue-primary);
+}
+
+/* ── 가이드 패널 ── */
+.setup-guide {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: 36px;
+  box-shadow: var(--shadow-card);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.guide-step {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.guide-step__num {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--color-navy-dark);
+  color: #fff;
+  font-size: 0.8rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.guide-step__body {
+  flex: 1;
+}
+
+.guide-step__body strong {
+  display: block;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin-bottom: 2px;
+}
+
+.guide-step__body p {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  margin-bottom: 10px;
+}
+
+/* 카드 미리보기 */
+.guide-preview-card {
+  background: linear-gradient(145deg, var(--color-navy-light), var(--color-navy-dark));
+  border-radius: var(--radius);
+  padding: 14px 18px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.guide-preview-card__pos {
+  font-size: 0.72rem;
+  color: rgba(255,255,255,0.5);
+  font-family: var(--font-en);
+}
+
+.guide-preview-card__word {
+  font-size: 1.4rem;
+  font-weight: 800;
+  color: #fff;
+}
+
+.guide-preview-card__sentence {
+  font-size: 0.75rem;
+  color: rgba(255,255,255,0.5);
+  font-style: italic;
+  text-align: center;
+}
+
+/* 입력 미리보기 */
+.guide-input-preview {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  border: 1.5px solid var(--color-blue-primary);
+  border-radius: var(--radius-sm);
+  padding: 8px 12px;
+  background: #fff;
+  width: fit-content;
+}
+
+.guide-input-preview__text {
+  font-size: 0.9rem;
+  font-family: var(--font-en);
+  color: var(--color-text-primary);
+}
+
+.guide-input-preview__cursor {
+  width: 1.5px;
+  height: 1rem;
+  background: var(--color-blue-primary);
+  animation: blink 1s step-end infinite;
+}
+
+@keyframes blink {
+  50% { opacity: 0; }
+}
+
+/* 결과 미리보기 */
+.guide-result-preview {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.guide-result-preview__score {
+  font-size: 1.8rem;
+  font-weight: 800;
+  font-family: var(--font-en);
+  color: var(--color-blue-primary);
+}
+
+.guide-result-preview__label {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
 }
 
 /* ── 진행 화면 ── */

--- a/js/api.js
+++ b/js/api.js
@@ -151,8 +151,8 @@ export const TestApi = {
    * POST /api/v1/test/sessions/:sessionId/answers
    * @returns {{ success, message, data: { sessionId, currentIndex, totalCount, isCorrect, isFinished, currentQuestion } }}
    */
-  submitAnswer(sessionId, wordId, userAnswer) {
-    return request('POST', `/api/v1/test/sessions/${sessionId}/answers`, { wordId, userAnswer });
+  submitAnswer(sessionId, wordId, userInput) {
+    return request('POST', `/api/v1/test/sessions/${sessionId}/answers`, { wordId, userInput });
   },
 
   /**

--- a/js/pages/test-history.js
+++ b/js/pages/test-history.js
@@ -43,7 +43,7 @@ function renderTable(records) {
 
   tbody.innerHTML = records.map(r => `
     <tr>
-      <td>${formatDate(r.finishedAt)}</td>
+      <td>${formatDate(r.startedAt)}</td>
       <td>${quizTypeLabel[r.quizType] ?? r.quizType}</td>
       <td>${r.totalCount}문제</td>
       <td><strong>${r.accuracy}%</strong></td>

--- a/js/pages/test.js
+++ b/js/pages/test.js
@@ -1,34 +1,16 @@
 import { TestApi } from '../api.js';
 import { auth } from '../auth.js';
-import { showToast, formatDuration } from '../utils.js';
+import { showToast, formatDuration, buildSidebar } from '../utils.js';
 
 auth.requireLogin();
-
-// ── 오늘 날짜 표시 ────────────────────────────────────────────
-(function setDate() {
-  const d = new Date();
-  const month = d.getMonth() + 1;
-  const day = d.getDate();
-  const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
-  document.getElementById('todayDate').textContent =
-    `${month}월 ${day}일 (${weekdays[d.getDay()]})`;
-})();
-
-// ── 로그아웃 ─────────────────────────────────────────────────
-import { AuthApi } from '../api.js';
-document.getElementById('logoutBtn').addEventListener('click', async () => {
-  try { await AuthApi.logout(); } catch (_) {}
-  auth.clearSession();
-  location.replace('./login.html');
-});
+buildSidebar('test');
 
 // ── 상태 ─────────────────────────────────────────────────────
-let sessionId      = null;
-let totalCount     = 10;
-let quizType       = 'SHORT_ANSWER';
-let currentIndex   = 0;
+let sessionId       = null;
+let totalCount      = 10;
+let currentIndex    = 0;
 let currentQuestion = null;
-let startTime      = null;
+let startTime       = null;
 
 // ── 화면 전환 ─────────────────────────────────────────────────
 function showView(id) {
@@ -38,20 +20,12 @@ function showView(id) {
 }
 
 // ── 설정 화면 ─────────────────────────────────────────────────
-const slider      = document.getElementById('totalCountSlider');
+const slider       = document.getElementById('totalCountSlider');
 const countDisplay = document.getElementById('totalCountDisplay');
 
 slider.addEventListener('input', () => {
   totalCount = Number(slider.value);
   countDisplay.textContent = totalCount;
-});
-
-document.querySelectorAll('.chip').forEach(chip => {
-  chip.addEventListener('click', () => {
-    document.querySelectorAll('.chip').forEach(c => c.classList.remove('chip--active'));
-    chip.classList.add('chip--active');
-    quizType = chip.dataset.type;
-  });
 });
 
 document.getElementById('startBtn').addEventListener('click', startTest);
@@ -62,20 +36,20 @@ async function startTest() {
   btn.textContent = '불러오는 중...';
 
   try {
-    const res = await TestApi.start(totalCount, quizType);
+    const res = await TestApi.start(totalCount, 'SHORT_ANSWER');
     if (!res || !res.success) {
       showToast(res?.message || '테스트를 시작할 수 없습니다.', 'error');
       return;
     }
 
-    sessionId      = res.data.sessionId;
-    totalCount     = res.data.totalCount;
-    currentIndex   = 0;
-    startTime      = Date.now();
+    sessionId    = res.data.sessionId;
+    totalCount   = res.data.totalCount;
+    currentIndex = 0;
+    startTime    = Date.now();
 
     initDots(totalCount);
     showView('quizView');
-    renderQuestion(res.data.currentQuestion);
+    renderQuestion(res.data.question);
   } catch {
     showToast('네트워크 오류가 발생했습니다.', 'error');
   } finally {
@@ -84,33 +58,26 @@ async function startTest() {
   }
 }
 
-// ── 문제 렌더링 ───────────────────────────────────────────────
+// ── 문제 렌더링 (한글 뜻 표시 → 영단어 입력) ──────────────────
 function renderQuestion(question) {
   currentQuestion = question;
 
-  document.getElementById('qPos').textContent      = question.pronunciation || '';
-  document.getElementById('qWord').textContent     = question.english;
+  document.getElementById('qPos').textContent      = question.partOfSpeech || '';
+  document.getElementById('qWord').textContent     = question.korean;
   document.getElementById('qSentence').textContent = question.exampleSentence || '';
 
   const progressPct = Math.round((currentIndex / totalCount) * 100);
   document.getElementById('progressText').textContent = `${currentIndex + 1} / ${totalCount}`;
   document.getElementById('progressFill').style.width = `${progressPct}%`;
 
-  if (quizType === 'SHORT_ANSWER') {
-    document.getElementById('shortAnswerArea').hidden    = false;
-    document.getElementById('multipleChoiceArea').hidden = true;
-    const input = document.getElementById('answerInput');
-    input.value = '';
-    input.disabled = false;
-    input.focus();
-    const confirmBtn = document.getElementById('confirmBtn');
-    confirmBtn.disabled = false;
-    confirmBtn.textContent = '확인';
-  } else {
-    document.getElementById('shortAnswerArea').hidden    = true;
-    document.getElementById('multipleChoiceArea').hidden = false;
-    renderChoices(question);
-  }
+  const input = document.getElementById('answerInput');
+  input.value = '';
+  input.disabled = false;
+  input.focus();
+
+  const confirmBtn = document.getElementById('confirmBtn');
+  confirmBtn.disabled = false;
+  confirmBtn.textContent = '확인';
 }
 
 // ── 주관식 제출 ───────────────────────────────────────────────
@@ -128,48 +95,30 @@ document.getElementById('answerInput').addEventListener('keydown', (e) => {
   }
 });
 
-// ── 객관식 렌더링 ─────────────────────────────────────────────
-function renderChoices(question) {
-  const grid = document.getElementById('choicesGrid');
-  // 백엔드에서 보기(choices)를 내려준다면 사용, 없으면 meaning만 정답으로
-  const choices = question.choices || [question.meaning];
-  grid.innerHTML = choices.map((choice, i) =>
-    `<button class="choice-btn" data-index="${i}">${escapeHtml(choice)}</button>`
-  ).join('');
-
-  grid.querySelectorAll('.choice-btn').forEach(btn => {
-    btn.addEventListener('click', () => {
-      grid.querySelectorAll('.choice-btn').forEach(b => b.disabled = true);
-      btn.classList.add('selected');
-      submitAnswer(btn.textContent);
-    });
-  });
-}
-
-// ── 답안 제출 공통 ────────────────────────────────────────────
-async function submitAnswer(userAnswer) {
+// ── 답안 제출 ────────────────────────────────────────────────
+async function submitAnswer(userInput) {
   const confirmBtn = document.getElementById('confirmBtn');
-  if (confirmBtn) confirmBtn.disabled = true;
-
-  const input = document.getElementById('answerInput');
-  if (input) input.disabled = true;
+  const input      = document.getElementById('answerInput');
+  confirmBtn.disabled = true;
+  input.disabled      = true;
 
   try {
-    const res = await TestApi.submitAnswer(sessionId, currentQuestion.wordId, userAnswer);
+    const res = await TestApi.submitAnswer(sessionId, currentQuestion.wordId, userInput);
     if (!res || !res.success) {
       showToast(res?.message || '오류가 발생했습니다.', 'error');
-      if (confirmBtn) confirmBtn.disabled = false;
-      if (input) input.disabled = false;
+      confirmBtn.disabled = false;
+      input.disabled      = false;
       return;
     }
 
-    const { isCorrect, isFinished, currentQuestion: nextQuestion } = res.data;
+    // Jackson boolean 직렬화: isCorrect→correct, isFinished→finished
+    const { correct, finished, nextQuestion } = res.data;
 
-    showFeedback(isCorrect);
-    updateDot(currentIndex, isCorrect);
+    showFeedback(correct);
+    updateDot(currentIndex, correct);
 
     setTimeout(async () => {
-      if (isFinished) {
+      if (finished) {
         await finishTest();
       } else {
         currentIndex++;
@@ -178,25 +127,16 @@ async function submitAnswer(userAnswer) {
     }, 800);
   } catch {
     showToast('네트워크 오류가 발생했습니다.', 'error');
-    if (confirmBtn) confirmBtn.disabled = false;
-    if (input) input.disabled = false;
+    confirmBtn.disabled = false;
+    input.disabled      = false;
   }
 }
 
 // ── 정/오답 피드백 ────────────────────────────────────────────
 function showFeedback(isCorrect) {
-  if (quizType === 'MULTIPLE_CHOICE') {
-    const grid = document.getElementById('choicesGrid');
-    grid.querySelectorAll('.choice-btn.selected').forEach(btn => {
-      btn.classList.add(isCorrect ? 'correct' : 'wrong');
-    });
-  }
-  // 주관식은 배경색 토글
   const input = document.getElementById('answerInput');
-  if (input) {
-    input.style.borderColor = isCorrect ? 'var(--color-success)' : 'var(--color-danger)';
-    setTimeout(() => { input.style.borderColor = ''; }, 700);
-  }
+  input.style.borderColor = isCorrect ? 'var(--color-success)' : 'var(--color-danger)';
+  setTimeout(() => { input.style.borderColor = ''; }, 700);
 }
 
 // ── 도트 인디케이터 ───────────────────────────────────────────
@@ -236,7 +176,7 @@ async function finishTest() {
 }
 
 function renderResult(data) {
-  const { totalCount: total, correctCount, accuracy, durationSec, wrongAnswers } = data;
+  const { totalCount: total, correctCount, accuracy, durationSec, wrongWords } = data;
 
   document.getElementById('resultAccuracy').textContent = `${accuracy}%`;
   document.getElementById('resultSummary').textContent  = `${total}문제 중 ${correctCount}개 정답`;
@@ -244,13 +184,15 @@ function renderResult(data) {
   document.getElementById('resultDuration').textContent = formatDuration(durationSec);
 
   const wrongSection = document.getElementById('wrongAnswerSection');
-  if (wrongAnswers && wrongAnswers.length > 0) {
+  if (wrongWords && wrongWords.length > 0) {
     wrongSection.hidden = false;
-    document.getElementById('wrongAnswerBody').innerHTML = wrongAnswers.map(w =>
+    // 퀴즈 방향: 한글 뜻 표시 → 영단어 입력
+    // wrongWords[i]: { english(정답), korean(출제된 한글 뜻), userInput(내 답) }
+    document.getElementById('wrongAnswerBody').innerHTML = wrongWords.map(w =>
       `<tr>
-        <td class="en">${escapeHtml(w.english)}</td>
-        <td class="wrong-answer">${escapeHtml(w.userAnswer ?? '-')}</td>
-        <td class="correct-answer">${escapeHtml(w.correctAnswer ?? w.meaning ?? '-')}</td>
+        <td>${escapeHtml(w.korean ?? '-')}</td>
+        <td class="wrong-answer">${escapeHtml(w.userInput ?? '-')}</td>
+        <td class="correct-answer en">${escapeHtml(w.english ?? '-')}</td>
       </tr>`
     ).join('');
   } else {

--- a/pages/test.html
+++ b/pages/test.html
@@ -6,45 +6,79 @@
   <title>LookEng — 테스트</title>
   <link rel="stylesheet" href="../css/global.css" />
   <link rel="stylesheet" href="../css/components.css" />
+  <link rel="stylesheet" href="../css/pages/word-list.css" />
   <link rel="stylesheet" href="../css/pages/test.css" />
 </head>
 <body>
-  <div class="topbar-layout">
-    <header class="topbar">
-      <span class="topbar__title">단어 퀴즈</span>
-      <div class="topbar__right">
-        <span id="todayDate"></span>
-        <button class="btn btn--ghost btn--sm" id="logoutBtn">로그아웃</button>
-      </div>
-    </header>
+  <div class="layout">
+    <div class="layout__sidebar" id="sidebar"></div>
 
-    <main class="topbar-layout__main">
+    <main class="layout__main">
 
       <!-- 설정 화면 -->
       <section id="setupView">
-        <div class="setup-card">
-          <h2 class="setup-card__title">퀴즈 설정</h2>
+        <h1 class="page-title" style="margin-bottom: 24px;">단어 퀴즈 세션</h1>
+        <div class="setup-layout">
 
-          <div class="setup-field">
-            <div class="setup-field__label">
-              <span>문제 수</span>
-              <span class="setup-field__value" id="totalCountDisplay">10</span>
+          <!-- 왼쪽: 퀴즈 설정 -->
+          <div class="setup-card">
+            <h2 class="setup-card__title">퀴즈 설정</h2>
+
+            <div class="setup-field">
+              <div class="setup-field__label">
+                <span>문제 수</span>
+                <span class="setup-field__value" id="totalCountDisplay">10</span>
+              </div>
+              <input type="range" class="slider" id="totalCountSlider"
+                     min="1" max="50" value="10" step="1" />
+              <div class="setup-field__hint">전체 단어 50개 중 랜덤으로 출제됩니다</div>
             </div>
-            <input type="range" class="slider" id="totalCountSlider"
-                   min="5" max="30" value="10" step="5" />
+
+            <button class="btn btn--primary btn--full" id="startBtn" style="margin-top:16px">시작하기</button>
           </div>
 
-          <div class="setup-field">
-            <div class="setup-field__label">
-              <span>퀴즈 유형</span>
-            </div>
-            <div class="chip-group">
-              <button class="chip chip--active" data-type="SHORT_ANSWER">주관식</button>
-              <button class="chip" data-type="MULTIPLE_CHOICE">객관식</button>
-            </div>
-          </div>
+          <!-- 오른쪽: 테스트 설명 -->
+          <div class="setup-guide">
+            <h2 class="setup-card__title">이렇게 진행돼요</h2>
 
-          <button class="btn btn--primary btn--full" id="startBtn" style="margin-top:8px">시작하기</button>
+            <div class="guide-step">
+              <div class="guide-step__num">1</div>
+              <div class="guide-step__body">
+                <strong>한글 뜻이 카드로 표시됩니다</strong>
+                <p>품사와 예문도 함께 제공돼요</p>
+                <div class="guide-preview-card">
+                  <span class="guide-preview-card__pos">noun</span>
+                  <span class="guide-preview-card__word">사과</span>
+                  <span class="guide-preview-card__sentence">"I eat an apple every day."</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="guide-step">
+              <div class="guide-step__num">2</div>
+              <div class="guide-step__body">
+                <strong>영단어를 직접 입력하세요</strong>
+                <p>대소문자는 구분하지 않아요</p>
+                <div class="guide-input-preview">
+                  <span class="guide-input-preview__text">apple</span>
+                  <span class="guide-input-preview__cursor"></span>
+                </div>
+              </div>
+            </div>
+
+            <div class="guide-step">
+              <div class="guide-step__num">3</div>
+              <div class="guide-step__body">
+                <strong>결과를 확인하세요</strong>
+                <p>정답률 · 소요 시간 · 오답 목록을 확인할 수 있어요</p>
+                <div class="guide-result-preview">
+                  <span class="guide-result-preview__score">80%</span>
+                  <span class="guide-result-preview__label">정답률</span>
+                </div>
+              </div>
+            </div>
+
+          </div>
         </div>
       </section>
 
@@ -67,18 +101,12 @@
 
         <!-- 주관식 입력 -->
         <div id="shortAnswerArea">
-          <p class="quiz-instruction">영단어의 한글 뜻을 입력하세요</p>
+          <p class="quiz-instruction">한글 뜻을 보고 영단어를 입력하세요</p>
           <div class="quiz-answer-row">
             <input type="text" class="input" id="answerInput"
-                   placeholder="예: 포기하다, 버리다" autocomplete="off" />
+                   placeholder="예: give up, abandon" autocomplete="off" />
             <button class="btn btn--primary" id="confirmBtn">확인</button>
           </div>
-        </div>
-
-        <!-- 객관식 보기 -->
-        <div id="multipleChoiceArea" hidden>
-          <p class="quiz-instruction">뜻으로 알맞은 것을 고르세요</p>
-          <div class="quiz-choices" id="choicesGrid"></div>
         </div>
 
         <!-- 하단 도트 인디케이터 -->
@@ -108,9 +136,9 @@
             <table class="data-table">
               <thead>
                 <tr>
-                  <th>영단어</th>
+                  <th>한글 뜻</th>
                   <th>내 답</th>
-                  <th>정답</th>
+                  <th>정답 (영단어)</th>
                 </tr>
               </thead>
               <tbody id="wrongAnswerBody"></tbody>
@@ -128,5 +156,6 @@
   </div>
 
   <script type="module" src="../js/pages/test.js"></script>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary

- `test.html` topbar 레이아웃 → **사이드바 레이아웃**으로 변경 (단어장과 UI 통일)
- 퀴즈 방향 확정: **한글 뜻 표시 → 영단어 입력** (백엔드 실제 구현과 일치)
- 객관식 UI 제거, 주관식 단독 운영
- 슬라이더 `step=1 / min=1 / max=50` 자유 설정
- 설정 화면에 **이용 가이드 패널** 추가 (2열 레이아웃)
- 콘텐츠 중앙 정렬 (max-width 900px)

## Bug Fixes

| 파일 | 수정 내용 |
|------|----------|
| `test.js` | `question.english` → `question.korean`, `question.pronunciation` → `question.partOfSpeech` |
| `test.js` | Jackson boolean 직렬화: `isCorrect` → `correct`, `isFinished` → `finished` |
| `test.js` | 답안 응답 필드: `currentQuestion` → `nextQuestion`, `wrongAnswers` → `wrongWords` |
| `api.js` | submitAnswer body: `userAnswer` → `userInput` (백엔드 DTO 필드명 일치) |
| `test-history.js` | 날짜 필드: `finishedAt` → `startedAt` |

## Test Plan

- [ ] 로그인 후 사이드바에 "단어 퀴즈 세션" 메뉴 및 활성 표시 확인
- [ ] 설정 화면: 슬라이더 1단위 조절 + 우측 가이드 패널 표시 확인
- [ ] 시작하기 → 카드에 **한글 뜻** 표시, 영단어 입력 동작 확인
- [ ] 정/오답 피드백 (입력창 테두리 색상, 하단 도트) 확인
- [ ] 마지막 문제 제출 → 결과 화면 자동 전환, 오답 테이블 확인
- [ ] 테스트 기록 메뉴 → 날짜 정상 표시 확인

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/claude-code)