### PR TITLE
✨ feat: 진도율/등급 UI 구현 및 API 연동 (#33)

### DIFF
--- a/css/pages/dashboard.css
+++ b/css/pages/dashboard.css
@@ -100,10 +100,10 @@
   cursor: pointer;
 }
 
-.grass-cell[data-level="1"] { background-color: #9BE9A8; }
-.grass-cell[data-level="2"] { background-color: #40C463; }
-.grass-cell[data-level="3"] { background-color: #30A14E; }
-.grass-cell[data-level="4"] { background-color: #216E39; }
+.grass-cell[data-level="1"] { background-color: #93C5FD; }
+.grass-cell[data-level="2"] { background-color: #3B82F6; }
+.grass-cell[data-level="3"] { background-color: #1D4ED8; }
+.grass-cell[data-level="4"] { background-color: #1E3A8A; }
 
 .grass-legend {
   display: flex;

--- a/css/pages/dashboard.css
+++ b/css/pages/dashboard.css
@@ -172,10 +172,14 @@
 }
 
 /* --- 등급 카드 --- */
+.level-section {
+  border: 1.5px solid #E2E8F0;
+}
+
 .level-display {
   display: flex;
   align-items: center;
-  gap: 24px;
+  gap: 28px;
 }
 
 .level-badge-wrap {
@@ -186,25 +190,34 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 72px;
-  height: 72px;
+  width: 88px;
+  height: 88px;
   border-radius: 50%;
-  background: var(--color-primary, #4A90E2);
+  background: #60A5FA;
   color: #fff;
-  font-size: 1.4rem;
+  font-size: 1.8rem;
   font-weight: 800;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  transition: background 0.3s ease;
 }
+
+/* 레벨별 배지 색상 (밝은 하늘 → 진한 네이비) */
+.level-badge[data-level="1"] { background: #60A5FA; }
+.level-badge[data-level="2"] { background: #3B82F6; }
+.level-badge[data-level="3"] { background: #1D4ED8; }
+.level-badge[data-level="4"] { background: #1E40AF; }
+.level-badge[data-level="5"] { background: #1E3A8A; }
 
 .level-info {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
 }
 
 .level-progress-bar {
   width: 100%;
-  height: 10px;
+  height: 12px;
   background: #E2E8F0;
   border-radius: 999px;
   overflow: hidden;
@@ -212,14 +225,22 @@
 
 .level-progress-bar__fill {
   height: 100%;
-  background: var(--color-primary, #4A90E2);
+  background: #60A5FA;
   border-radius: 999px;
-  transition: width 0.4s ease;
+  transition: width 0.4s ease, background 0.3s ease;
 }
+
+/* 레벨별 진도 바 색상 */
+.level-progress-bar__fill[data-level="1"] { background: #60A5FA; }
+.level-progress-bar__fill[data-level="2"] { background: #3B82F6; }
+.level-progress-bar__fill[data-level="3"] { background: #1D4ED8; }
+.level-progress-bar__fill[data-level="4"] { background: #1E40AF; }
+.level-progress-bar__fill[data-level="5"] { background: #1E3A8A; }
 
 .level-info__texts {
   display: flex;
   justify-content: space-between;
-  font-size: 0.9rem;
-  color: #64748B;
+  font-size: 1rem;
+  font-weight: 500;
+  color: #475569;
 }

--- a/css/pages/dashboard.css
+++ b/css/pages/dashboard.css
@@ -170,3 +170,56 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* --- 등급 카드 --- */
+.level-display {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+}
+
+.level-badge-wrap {
+  flex-shrink: 0;
+}
+
+.level-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: var(--color-primary, #4A90E2);
+  color: #fff;
+  font-size: 1.4rem;
+  font-weight: 800;
+}
+
+.level-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.level-progress-bar {
+  width: 100%;
+  height: 10px;
+  background: #E2E8F0;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.level-progress-bar__fill {
+  height: 100%;
+  background: var(--color-primary, #4A90E2);
+  border-radius: 999px;
+  transition: width 0.4s ease;
+}
+
+.level-info__texts {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: #64748B;
+}

--- a/css/pages/word-list.css
+++ b/css/pages/word-list.css
@@ -156,9 +156,14 @@
   margin-bottom: 24px;
   box-shadow: var(--shadow-sm);
   display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.progress-section__header {
+  display: flex;
+  justify-content: space-between;
   align-items: center;
-  gap: 20px;
-  flex-wrap: wrap;
 }
 
 .progress-section__label {
@@ -167,9 +172,17 @@
   white-space: nowrap;
 }
 
+.progress-level-badge {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--color-blue-primary, #4A90E2);
+  background: #EBF4FF;
+  padding: 2px 10px;
+  border-radius: 999px;
+}
+
 .progress-bar {
-  flex: 1;
-  min-width: 160px;
+  width: 100%;
   height: 8px;
   background: var(--color-bg);
   border-radius: 99px;
@@ -183,10 +196,22 @@
   transition: width 0.4s ease;
 }
 
+.progress-section__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
 .progress-section__count {
   font-size: 0.875rem;
   font-weight: 600;
   color: var(--color-text-primary);
+  white-space: nowrap;
+}
+
+.progress-section__next {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
   white-space: nowrap;
 }
 

--- a/css/pages/word-list.css
+++ b/css/pages/word-list.css
@@ -157,7 +157,7 @@
   box-shadow: var(--shadow-sm);
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
 }
 
 .progress-section__header {
@@ -167,33 +167,62 @@
 }
 
 .progress-section__label {
-  font-size: 0.875rem;
+  font-size: 1rem;
+  font-weight: 600;
   color: var(--color-text-secondary);
   white-space: nowrap;
 }
 
 .progress-level-badge {
-  font-size: 0.85rem;
+  font-size: 1rem;
   font-weight: 700;
   color: var(--color-blue-primary, #4A90E2);
   background: #EBF4FF;
-  padding: 2px 10px;
+  padding: 4px 14px;
   border-radius: 999px;
 }
 
+/* 진도 바 */
 .progress-bar {
+  position: relative;
   width: 100%;
-  height: 8px;
+  height: 12px;
   background: var(--color-bg);
   border-radius: 99px;
   overflow: hidden;
 }
 
+/* 쉬머 애니메이션 */
+@keyframes shimmer {
+  0%   { background-position: -300% center; }
+  100% { background-position: 300% center; }
+}
+
 .progress-bar__fill {
   height: 100%;
-  background: linear-gradient(90deg, var(--color-blue-primary), var(--color-navy-light));
+  background: linear-gradient(
+    90deg,
+    #3B82F6 0%,
+    #60A5FA 35%,
+    #93C5FD 50%,
+    #60A5FA 65%,
+    #3B82F6 100%
+  );
+  background-size: 300% 100%;
   border-radius: 99px;
-  transition: width 0.4s ease;
+  animation: shimmer 3s ease-in-out infinite;
+  transition: width 0.5s ease;
+}
+
+/* 레벨 구간 마커 (흰 눈금선) */
+.progress-bar__marker {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: rgba(255, 255, 255, 0.75);
+  pointer-events: none;
+  z-index: 2;
 }
 
 .progress-section__footer {
@@ -203,16 +232,43 @@
 }
 
 .progress-section__count {
-  font-size: 0.875rem;
-  font-weight: 600;
+  font-size: 1rem;
+  font-weight: 700;
   color: var(--color-text-primary);
   white-space: nowrap;
 }
 
 .progress-section__next {
-  font-size: 0.85rem;
+  font-size: 0.95rem;
+  font-weight: 500;
   color: var(--color-text-secondary);
   white-space: nowrap;
+}
+
+/* 레벨업 토스트 */
+.levelup-toast {
+  position: fixed;
+  top: 28px;
+  left: 50%;
+  transform: translateX(-50%) translateY(-120px);
+  background: linear-gradient(135deg, #1D4ED8, #1E3A8A);
+  color: #fff;
+  padding: 16px 36px;
+  border-radius: 999px;
+  font-size: 1.15rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  box-shadow: 0 8px 32px rgba(30, 58, 138, 0.45);
+  z-index: 9999;
+  opacity: 0;
+  transition: transform 0.45s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.3s;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+.levelup-toast--show {
+  transform: translateX(-50%) translateY(0);
+  opacity: 1;
 }
 
 /* 컨트롤 바 */

--- a/js/api.js
+++ b/js/api.js
@@ -219,6 +219,13 @@ export const UserWordApi = {
   },
 };
 
+// ── Progress API ──────────────────────────────────────────────
+export const ProgressApi = {
+  getProgress() {
+    return request('GET', '/api/v1/user/progress');
+  },
+};
+
 // ── Admin API ─────────────────────────────────────────────────
 export const AdminApi = {
   getUsers() {

--- a/js/pages/dashboard.js
+++ b/js/pages/dashboard.js
@@ -1,4 +1,4 @@
-import { TestApi, AuthApi } from '../api.js';
+import { TestApi, AuthApi, ProgressApi } from '../api.js';
 import { auth } from '../auth.js';
 import { showToast, buildSidebar } from '../utils.js';
 
@@ -10,6 +10,24 @@ function renderUserName() {
   const nameDisplay = document.getElementById('userName');
   if (nameDisplay) {
     nameDisplay.textContent = email.split('@')[0];
+  }
+}
+
+async function loadProgress() {
+  try {
+    const res = await ProgressApi.getProgress();
+    if (!res?.success) return;
+    const { level, memorizedWords, totalWords, wordsToNextLevel } = res.data;
+
+    document.getElementById('levelBadge').textContent = `Lv.${level}`;
+    document.getElementById('levelMemorized').textContent = `암기완료 ${memorizedWords} / ${totalWords}`;
+    document.getElementById('levelNext').textContent =
+      level >= 5 ? '최고 등급 달성! 🎉' : `다음 등급까지 ${wordsToNextLevel}개`;
+
+    const pct = totalWords > 0 ? Math.round((memorizedWords / totalWords) * 100) : 0;
+    document.getElementById('levelProgressFill').style.width = `${pct}%`;
+  } catch {
+    // 조용히 무시 (대시보드 다른 기능에 영향 없게)
   }
 }
 
@@ -156,5 +174,6 @@ function bindTooltipEvents() {
 
 document.addEventListener('DOMContentLoaded', () => {
   renderUserName();
+  loadProgress();
   loadGrassCalendarData();
 });

--- a/js/pages/dashboard.js
+++ b/js/pages/dashboard.js
@@ -19,13 +19,18 @@ async function loadProgress() {
     if (!res?.success) return;
     const { level, memorizedWords, totalWords, wordsToNextLevel } = res.data;
 
-    document.getElementById('levelBadge').textContent = `Lv.${level}`;
+    const badge = document.getElementById('levelBadge');
+    badge.textContent = `Lv.${level}`;
+    badge.dataset.level = level;
+
     document.getElementById('levelMemorized').textContent = `암기완료 ${memorizedWords} / ${totalWords}`;
     document.getElementById('levelNext').textContent =
       level >= 5 ? '최고 등급 달성! 🎉' : `다음 등급까지 ${wordsToNextLevel}개`;
 
     const pct = totalWords > 0 ? Math.round((memorizedWords / totalWords) * 100) : 0;
-    document.getElementById('levelProgressFill').style.width = `${pct}%`;
+    const fill = document.getElementById('levelProgressFill');
+    fill.style.width = `${pct}%`;
+    fill.dataset.level = level;
   } catch {
     // 조용히 무시 (대시보드 다른 기능에 영향 없게)
   }

--- a/js/pages/word-list.js
+++ b/js/pages/word-list.js
@@ -26,6 +26,7 @@ let memorizedCount = 0;
 let currentFilter  = 'all'; // 'all' | 'bookmarked' | 'memorized'
 let currentLevel       = 1;
 let wordsToNextLevel   = 0;
+let prevMemorizedCount = 0;
 let filteredWords  = [];
 let searchKeyword  = '';
 let searchDebounce = null;
@@ -35,11 +36,76 @@ const searchInput = document.getElementById('searchInput');
 const searchClear = document.getElementById('searchClear');
 const sortSelect  = document.getElementById('sortSelect');
 
+// ── 숫자 카운트업 애니메이션 ─────────────────────────────────
+function animateCount(fromVal, toVal) {
+  const countEl = document.getElementById('progressCount');
+  const duration = 600;
+  const startTime = Date.now();
+  const tick = () => {
+    const elapsed = Date.now() - startTime;
+    const t = Math.min(elapsed / duration, 1);
+    const eased = 1 - Math.pow(1 - t, 3); // ease-out cubic
+    const current = Math.round(fromVal + (toVal - fromVal) * eased);
+    countEl.textContent = `암기완료 ${current} / ${totalElements}`;
+    if (t < 1) {
+      requestAnimationFrame(tick);
+    } else {
+      prevMemorizedCount = toVal;
+    }
+  };
+  requestAnimationFrame(tick);
+}
+
+// ── 레벨업 토스트 배너 ────────────────────────────────────────
+function showLevelUpToast(newLevel) {
+  const existing = document.querySelector('.levelup-toast');
+  if (existing) existing.remove();
+
+  const toast = document.createElement('div');
+  toast.className = 'levelup-toast';
+  toast.innerHTML = `🎉 레벨 업! <strong>Lv.${newLevel}</strong> 달성!`;
+  document.body.appendChild(toast);
+
+  // 두 프레임 뒤에 show 클래스 적용 (transition 동작을 위해)
+  requestAnimationFrame(() => requestAnimationFrame(() => toast.classList.add('levelup-toast--show')));
+
+  setTimeout(() => {
+    toast.classList.remove('levelup-toast--show');
+    setTimeout(() => toast.remove(), 450);
+  }, 3000);
+}
+
+// ── 폭죽 (canvas-confetti) ────────────────────────────────────
+function triggerConfetti() {
+  if (typeof confetti === 'undefined') return;
+
+  // 1. 중앙 폭발
+  confetti({
+    particleCount: 180,
+    spread: 100,
+    origin: { y: 0.35 },
+    colors: ['#60A5FA', '#3B82F6', '#FBBF24', '#F472B6', '#34D399'],
+  });
+
+  // 2. 0.3초 후 좌우 동시 발사
+  setTimeout(() => {
+    confetti({ particleCount: 80, angle: 60,  spread: 55, origin: { x: 0 } });
+    confetti({ particleCount: 80, angle: 120, spread: 55, origin: { x: 1 } });
+  }, 300);
+}
+
 // ── 진도 바 ──────────────────────────────────────────────────
-function updateProgress() {
+function updateProgress(animate = false) {
   const pct = totalElements > 0 ? Math.round((memorizedCount / totalElements) * 100) : 0;
   document.getElementById('progressFill').style.width = `${pct}%`;
-  document.getElementById('progressCount').textContent = `암기완료 ${memorizedCount} / ${totalElements}`;
+
+  if (animate) {
+    animateCount(prevMemorizedCount, memorizedCount);
+  } else {
+    document.getElementById('progressCount').textContent = `암기완료 ${memorizedCount} / ${totalElements}`;
+    prevMemorizedCount = memorizedCount;
+  }
+
   document.getElementById('progressLevel').textContent = `Lv.${currentLevel}`;
   document.getElementById('progressNext').textContent =
     currentLevel >= 5 ? '최고 등급 달성! 🎉' : `다음 등급까지 ${wordsToNextLevel}개`;
@@ -309,7 +375,9 @@ async function toggleMemorized(wordId) {
     const isMemorized = res.data.isMemorized;
 
     // 1. 진도 카운트 업데이트 (API에서 최신 level 포함 재조회)
+    const oldLevel = currentLevel;
     const progressRes = await ProgressApi.getProgress();
+    prevMemorizedCount = memorizedCount;
     if (progressRes?.success) {
       memorizedCount   = progressRes.data.memorizedWords;
       currentLevel     = progressRes.data.level;
@@ -317,7 +385,13 @@ async function toggleMemorized(wordId) {
     } else {
       memorizedCount += isMemorized ? 1 : -1;
     }
-    updateProgress();
+    updateProgress(true);
+
+    // 2. 레벨업 감지 → 폭죽 + 토스트
+    if (currentLevel > oldLevel) {
+      showLevelUpToast(currentLevel);
+      triggerConfetti();
+    }
 
     // 2. 카드 UI 업데이트
     const wrapper = document.querySelector(`.word-card-wrapper[data-word-id="${wordId}"]`);
@@ -459,9 +533,10 @@ async function init() {
   const { content, totalElements: total, totalPages } = wordsRes.data;
   totalElements = total;
   if (progressRes?.success) {
-    memorizedCount   = progressRes.data.memorizedWords;
-    currentLevel     = progressRes.data.level;
-    wordsToNextLevel = progressRes.data.wordsToNextLevel;
+    memorizedCount     = progressRes.data.memorizedWords;
+    currentLevel       = progressRes.data.level;
+    wordsToNextLevel   = progressRes.data.wordsToNextLevel;
+    prevMemorizedCount = memorizedCount;
   }
 
   document.getElementById('totalCount').textContent = `총 ${total}개`;

--- a/js/pages/word-list.js
+++ b/js/pages/word-list.js
@@ -1,4 +1,4 @@
-import { WordApi, UserWordApi } from '../api.js';
+import { WordApi, UserWordApi, ProgressApi } from '../api.js';
 import { auth } from '../auth.js';
 import { showToast, buildSidebar, renderPagination, getPosClass } from '../utils.js';
 
@@ -24,6 +24,8 @@ let currentSort    = 'english,asc';
 let totalElements  = 0;
 let memorizedCount = 0;
 let currentFilter  = 'all'; // 'all' | 'bookmarked' | 'memorized'
+let currentLevel       = 1;
+let wordsToNextLevel   = 0;
 let filteredWords  = [];
 let searchKeyword  = '';
 let searchDebounce = null;
@@ -38,6 +40,9 @@ function updateProgress() {
   const pct = totalElements > 0 ? Math.round((memorizedCount / totalElements) * 100) : 0;
   document.getElementById('progressFill').style.width = `${pct}%`;
   document.getElementById('progressCount').textContent = `암기완료 ${memorizedCount} / ${totalElements}`;
+  document.getElementById('progressLevel').textContent = `Lv.${currentLevel}`;
+  document.getElementById('progressNext').textContent =
+    currentLevel >= 5 ? '최고 등급 달성! 🎉' : `다음 등급까지 ${wordsToNextLevel}개`;
 }
 
 // ── 전체 단어 로드 (페이지네이션) ────────────────────────────
@@ -303,8 +308,15 @@ async function toggleMemorized(wordId) {
 
     const isMemorized = res.data.isMemorized;
 
-    // 1. 진도 카운트 업데이트
-    memorizedCount += isMemorized ? 1 : -1;
+    // 1. 진도 카운트 업데이트 (API에서 최신 level 포함 재조회)
+    const progressRes = await ProgressApi.getProgress();
+    if (progressRes?.success) {
+      memorizedCount   = progressRes.data.memorizedWords;
+      currentLevel     = progressRes.data.level;
+      wordsToNextLevel = progressRes.data.wordsToNextLevel;
+    } else {
+      memorizedCount += isMemorized ? 1 : -1;
+    }
     updateProgress();
 
     // 2. 카드 UI 업데이트
@@ -433,10 +445,10 @@ sortSelect.addEventListener('change', (e) => {
 
 // ── 초기 로드 ─────────────────────────────────────────────────
 async function init() {
-  // 1. 단어 목록과 암기완료 목록을 병렬 조회
-  const [wordsRes, memorizedRes] = await Promise.all([
+  // 1. 단어 목록과 진도 정보를 병렬 조회
+  const [wordsRes, progressRes] = await Promise.all([
     WordApi.getList(0, PAGE_SIZE, currentSort).catch(() => null),
-    auth.isAdmin() ? Promise.resolve(null) : UserWordApi.getMemorized().catch(() => null),
+    auth.isAdmin() ? Promise.resolve(null) : ProgressApi.getProgress().catch(() => null),
   ]);
 
   if (!wordsRes || !wordsRes.success) {
@@ -446,7 +458,11 @@ async function init() {
 
   const { content, totalElements: total, totalPages } = wordsRes.data;
   totalElements = total;
-  memorizedCount = memorizedRes?.success ? (memorizedRes.data || []).length : 0;
+  if (progressRes?.success) {
+    memorizedCount   = progressRes.data.memorizedWords;
+    currentLevel     = progressRes.data.level;
+    wordsToNextLevel = progressRes.data.wordsToNextLevel;
+  }
 
   document.getElementById('totalCount').textContent = `총 ${total}개`;
   renderWordGrid(content);

--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -24,6 +24,24 @@
           </div>
         </section>
 
+        <section class="level-section card">
+          <h2 class="section-title">나의 등급</h2>
+          <div class="level-display">
+            <div class="level-badge-wrap">
+              <span class="level-badge" id="levelBadge">Lv.1</span>
+            </div>
+            <div class="level-info">
+              <div class="level-progress-bar">
+                <div class="level-progress-bar__fill" id="levelProgressFill" style="width: 0%"></div>
+              </div>
+              <div class="level-info__texts">
+                <span id="levelMemorized">암기완료 0 / 50</span>
+                <span id="levelNext">다음 등급까지 10개</span>
+              </div>
+            </div>
+          </div>
+        </section>
+
         <section class="learning-record-section card">
           <h2 class="section-title">나의 학습 기록</h2>
           <div class="grass-calendar-wrapper">

--- a/pages/word-list.html
+++ b/pages/word-list.html
@@ -21,11 +21,17 @@
 
       <!-- 학습 진도 바 -->
       <div class="progress-section">
-        <span class="progress-section__label">학습 진도</span>
+        <div class="progress-section__header">
+          <span class="progress-section__label">학습 진도</span>
+          <span class="progress-level-badge" id="progressLevel">Lv.1</span>
+        </div>
         <div class="progress-bar">
           <div class="progress-bar__fill" id="progressFill" style="width: 0%"></div>
         </div>
-        <span class="progress-section__count" id="progressCount">암기완료 0 / 0</span>
+        <div class="progress-section__footer">
+          <span class="progress-section__count" id="progressCount">암기완료 0 / 0</span>
+          <span class="progress-section__next" id="progressNext">다음 등급까지 10개</span>
+        </div>
       </div>
 
       <!-- 검색창 -->

--- a/pages/word-list.html
+++ b/pages/word-list.html
@@ -27,6 +27,10 @@
         </div>
         <div class="progress-bar">
           <div class="progress-bar__fill" id="progressFill" style="width: 0%"></div>
+          <span class="progress-bar__marker" style="left:20%"></span>
+          <span class="progress-bar__marker" style="left:40%"></span>
+          <span class="progress-bar__marker" style="left:60%"></span>
+          <span class="progress-bar__marker" style="left:80%"></span>
         </div>
         <div class="progress-section__footer">
           <span class="progress-section__count" id="progressCount">암기완료 0 / 0</span>
@@ -76,6 +80,7 @@
     </main>
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.browser.min.js"></script>
   <script type="module" src="../js/pages/word-list.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## 개요
`GET /api/v1/user/progress` API를 프론트엔드에 연동하여
단어장과 대시보드에 진도율/등급 UI를 구현합니다.

Closes #33

---

## 변경 사항

### ✨ feat
- `api.js`: `ProgressApi.getProgress()` 추가
- **단어장**: 진도 바에 레벨 배지(`Lv.N`) + 다음 등급까지 남은 개수 표시
- **단어장**: 암기 토글 시 `ProgressApi` 재조회로 레벨 실시간 갱신
- **대시보드**: "나의 등급" 카드 섹션 신규 추가 (레벨 배지, 진도 바, 암기 수)

### ✨ feat — 애니메이션
- 진도 바 **쉬머(shimmer) 애니메이션** (빛이 흐르는 효과)
- 레벨 구간 **눈금 마커** (Lv.1~5 경계선 4개)
- 암기 토글 시 숫자 **카운트업 애니메이션** (0 → N 부드럽게)
- 레벨업 감지 시 **토스트 배너** 슬라이드 등장 + **canvas-confetti 폭죽** 🎊

### 💄 style
- 레벨 1~5에 따라 배지·진도 바 색상 변화 (하늘색 → 진한 네이비)
- 진도 섹션 텍스트 전체 크기 확대
- 잔디 캘린더 색상 초록 → 네이비 계열로 통일

---

## 레벨별 색상

| 레벨 | 색상 |
|---|---|
| Lv.1 | `#60A5FA` 하늘색 |
| Lv.2 | `#3B82F6` 파랑 |
| Lv.3 | `#1D4ED8` 진한 파랑 |
| Lv.4 | `#1E40AF` 네이비 |
| Lv.5 | `#1E3A8A` 진한 네이비 |

---

## 레벨업 플로우

암기 토글 → API 재조회 → level 증가 감지
→ 상단 토스트 배너 등장 + 폭죽 3연발 🎊
→ 진도 숫자 카운트업 애니메이션
→ 3초 후 배너 자동 퇴장

---
clsos #33 