### PR TITLE
✨ feat: 퀴즈 유형 확장 — 4지선다/빈칸채우기 설정·진행 화면 및 용어 통일 (#35)

### DIFF
--- a/css/pages/admin.css
+++ b/css/pages/admin.css
@@ -274,7 +274,7 @@
 
 .pagination__btn:disabled { opacity: 0.35; cursor: not-allowed; }
 
-/* ── 넓은 모달 (퀴즈 세션 기록 등) ── */
+/* ── 넓은 모달 (테스트 세션 기록 등) ── */
 .modal--wide {
   max-width: 620px;
 }
@@ -310,7 +310,7 @@
   color: #fff;
 }
 
-/* ── 사용자 그리드 (퀴즈 세션 페이지) ── */
+/* ── 사용자 그리드 (테스트 세션 페이지) ── */
 .user-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));

--- a/css/pages/test.css
+++ b/css/pages/test.css
@@ -353,6 +353,15 @@
 .quiz-word-card__word    { font-size: 2.25rem; font-weight: 800; font-family: var(--font-en); line-height: 1.1; }
 .quiz-word-card__sentence { font-size: 0.875rem; color: rgba(255,255,255,0.55); font-style: italic; max-width: 480px; line-height: 1.5; }
 
+/* FILL_IN_BLANK — 예문을 메인으로 강조 */
+.quiz-word-card--fib .quiz-word-card__sentence {
+  font-size: 1.1rem;
+  color: rgba(255,255,255,0.9);
+  font-style: normal;
+  line-height: 1.7;
+  max-width: 520px;
+}
+
 /* 주관식 입력 */
 .quiz-instruction {
   font-size: 0.875rem;

--- a/css/pages/test.css
+++ b/css/pages/test.css
@@ -57,7 +57,48 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 24px;
-  align-items: start;
+  align-items: stretch;   /* 양쪽 카드 높이 동일 */
+}
+
+/* ── 가이드 유형별 패널 ── */
+.guide-content {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+/* 객관식/빈칸 가이드 미리보기 선택지 */
+.guide-choices-preview {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.guide-choice-item {
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  border: 1.5px solid var(--color-border);
+  font-size: 0.82rem;
+  font-weight: 600;
+  font-family: var(--font-en);
+  color: var(--color-text-secondary);
+  text-align: center;
+}
+
+.guide-choice-item--correct {
+  border-color: var(--color-success);
+  background: var(--color-success-bg);
+  color: var(--color-success);
+}
+
+/* ── 하단 최근 기록 박스 (독립) ── */
+.recent-history-box {
+  margin-top: 24px;
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: 28px 36px;
+  box-shadow: var(--shadow-card);
 }
 
 /* ── 설정 화면 ── */
@@ -499,23 +540,15 @@
   color: var(--color-text-muted);
 }
 
-/* ── 설정 화면: 최근 기록 ── */
-.recent-history {
-  margin-top: 24px;
-  padding-top: 20px;
-  border-top: 1px solid var(--color-border);
-}
-
+/* ── 하단 최근 기록: 타이틀 / 행 스타일 ── */
 .recent-history__title {
-  font-size: 0.8125rem;
-  font-weight: 600;
-  color: var(--color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  margin-bottom: 10px;
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin-bottom: 14px;
 }
 
-/* session-row 그리드: 날짜 | 유형 | 문제수 | 정답률 (duration 제외) */
-.recent-history .session-row {
-  grid-template-columns: 90px 60px 60px 1fr;
+/* session-row 그리드: 날짜 | 유형 | 문제수 | 정답률 */
+.recent-history-box .session-row {
+  grid-template-columns: 100px 72px 64px 1fr;
 }

--- a/css/pages/test.css
+++ b/css/pages/test.css
@@ -148,7 +148,7 @@
   cursor: pointer;
 }
 
-/* 퀴즈 타입 칩 */
+/* 테스트 유형 칩 */
 .chip-group {
   display: flex;
   gap: 10px;

--- a/css/pages/test.css
+++ b/css/pages/test.css
@@ -156,7 +156,7 @@
 
 .chip {
   flex: 1;
-  padding: 14px 20px;
+  padding: 14px 10px;
   border-radius: var(--radius-sm);
   border: 1.5px solid var(--color-border);
   background: var(--color-surface);
@@ -166,6 +166,7 @@
   cursor: pointer;
   transition: all var(--transition-fast);
   text-align: center;
+  white-space: nowrap;
 }
 
 .chip:hover { border-color: var(--color-blue-primary); color: var(--color-blue-primary); }

--- a/css/pages/test.css
+++ b/css/pages/test.css
@@ -156,11 +156,11 @@
 
 .chip {
   flex: 1;
-  padding: 10px 16px;
+  padding: 14px 20px;
   border-radius: var(--radius-sm);
   border: 1.5px solid var(--color-border);
   background: var(--color-surface);
-  font-size: 0.9rem;
+  font-size: 1rem;
   font-weight: 600;
   color: var(--color-text-secondary);
   cursor: pointer;

--- a/js/pages/admin/quiz-session.js
+++ b/js/pages/admin/quiz-session.js
@@ -50,7 +50,7 @@ function renderUserGrid(users) {
 
 // ── 유저 세션 기록 모달 오픈 ──────────────────────────────────
 async function openSessionModal(userId, userName) {
-  modalUserName.textContent = `${userName}의 퀴즈 기록`;
+  modalUserName.textContent = `${userName}의 테스트 기록`;
   sessionList.innerHTML = '<div class="session-list__loading">불러오는 중…</div>';
   sessionsModal.classList.add('is-open');
 
@@ -77,7 +77,7 @@ function getAccuracyClass(accuracy) {
 
 function renderSessionList(records) {
   if (!records || !records.length) {
-    sessionList.innerHTML = '<div class="session-list__empty">퀴즈 기록이 없습니다.</div>';
+    sessionList.innerHTML = '<div class="session-list__empty">테스트 기록이 없습니다.</div>';
     return;
   }
 

--- a/js/pages/test-history.js
+++ b/js/pages/test-history.js
@@ -39,12 +39,12 @@ function renderTable(records) {
     return;
   }
 
-  const quizTypeLabel = { SHORT_ANSWER: '주관식', MULTIPLE_CHOICE: '객관식' };
+  const quizTypeLabel = { SHORT_ANSWER: '주관식', MULTIPLE_CHOICE: '객관식', FILL_IN_BLANK: '빈칸채우기' };
 
   tbody.innerHTML = records.map(r => `
     <tr>
       <td>${formatDate(r.startedAt)}</td>
-      <td>${quizTypeLabel[r.quizType] ?? r.quizType}</td>
+      <td><span class="session-row__type">${quizTypeLabel[r.quizType] ?? r.quizType}</span></td>
       <td>${r.totalCount}문제</td>
       <td><strong>${r.accuracy}%</strong></td>
       <td>${formatDuration(r.durationSec)}</td>

--- a/js/pages/test.js
+++ b/js/pages/test.js
@@ -60,11 +60,12 @@ document.querySelectorAll('.chip[data-quiz-type]').forEach(chip => {
 });
 
 // ── 상태 ─────────────────────────────────────────────────────
-let sessionId       = null;
-let totalCount      = 10;
-let currentIndex    = 0;
-let currentQuestion = null;
-let startTime       = null;
+let sessionId        = null;
+let totalCount       = 10;
+let currentIndex     = 0;
+let currentQuestion  = null;
+let startTime        = null;
+let currentQuizType  = 'SHORT_ANSWER';
 
 // ── 화면 전환 ─────────────────────────────────────────────────
 function showView(id) {
@@ -96,10 +97,11 @@ async function startTest() {
       return;
     }
 
-    sessionId    = res.data.sessionId;
-    totalCount   = res.data.totalCount;
-    currentIndex = 0;
-    startTime    = Date.now();
+    sessionId       = res.data.sessionId;
+    totalCount      = res.data.totalCount;
+    currentIndex    = 0;
+    startTime       = Date.now();
+    currentQuizType = selectedQuizType;
 
     initDots(totalCount);
     showView('quizView');
@@ -112,26 +114,53 @@ async function startTest() {
   }
 }
 
-// ── 문제 렌더링 (한글 뜻 표시 → 영단어 입력) ──────────────────
+// ── 문제 렌더링 ───────────────────────────────────────────────
 function renderQuestion(question) {
   currentQuestion = question;
-
-  document.getElementById('qPos').textContent      = question.partOfSpeech || '';
-  document.getElementById('qWord').textContent     = question.korean;
-  document.getElementById('qSentence').textContent = question.exampleSentence || '';
 
   const progressPct = Math.round((currentIndex / totalCount) * 100);
   document.getElementById('progressText').textContent = `${currentIndex + 1} / ${totalCount}`;
   document.getElementById('progressFill').style.width = `${progressPct}%`;
 
-  const input = document.getElementById('answerInput');
-  input.value = '';
-  input.disabled = false;
-  input.focus();
+  const card = document.querySelector('.quiz-word-card');
+  document.getElementById('qPos').textContent = question.partOfSpeech || '';
 
-  const confirmBtn = document.getElementById('confirmBtn');
-  confirmBtn.disabled = false;
-  confirmBtn.textContent = '확인';
+  if (currentQuizType === 'FILL_IN_BLANK') {
+    card.classList.add('quiz-word-card--fib');
+    document.getElementById('qWord').textContent     = '';
+    document.getElementById('qSentence').textContent = question.sentence || '';
+  } else {
+    card.classList.remove('quiz-word-card--fib');
+    document.getElementById('qWord').textContent     = question.korean;
+    document.getElementById('qSentence').textContent =
+      currentQuizType === 'SHORT_ANSWER' ? (question.exampleSentence || '') : '';
+  }
+
+  if (currentQuizType === 'SHORT_ANSWER') {
+    document.getElementById('shortAnswerArea').hidden = false;
+    document.getElementById('choicesArea').hidden     = true;
+    const input = document.getElementById('answerInput');
+    input.value    = '';
+    input.disabled = false;
+    input.focus();
+    const confirmBtn = document.getElementById('confirmBtn');
+    confirmBtn.disabled    = false;
+    confirmBtn.textContent = '확인';
+  } else {
+    document.getElementById('shortAnswerArea').hidden = true;
+    document.getElementById('choicesArea').hidden     = false;
+    renderChoices(question.choices || []);
+  }
+}
+
+function renderChoices(choices) {
+  const grid = document.getElementById('choicesGrid');
+  grid.innerHTML = choices.map(c =>
+    `<button class="choice-btn" data-choice="${escapeHtml(c)}">${escapeHtml(c)}</button>`
+  ).join('');
+  grid.querySelectorAll('.choice-btn').forEach(btn => {
+    btn.addEventListener('click', () => submitAnswer(btn.dataset.choice));
+  });
 }
 
 // ── 주관식 제출 ───────────────────────────────────────────────
@@ -150,25 +179,39 @@ document.getElementById('answerInput').addEventListener('keydown', (e) => {
 });
 
 // ── 답안 제출 ────────────────────────────────────────────────
+function lockInput() {
+  if (currentQuizType === 'SHORT_ANSWER') {
+    document.getElementById('confirmBtn').disabled    = true;
+    document.getElementById('answerInput').disabled   = true;
+  } else {
+    document.querySelectorAll('#choicesGrid .choice-btn').forEach(b => { b.disabled = true; });
+  }
+}
+
+function unlockInput() {
+  if (currentQuizType === 'SHORT_ANSWER') {
+    document.getElementById('confirmBtn').disabled    = false;
+    document.getElementById('answerInput').disabled   = false;
+  } else {
+    document.querySelectorAll('#choicesGrid .choice-btn').forEach(b => { b.disabled = false; });
+  }
+}
+
 async function submitAnswer(userInput) {
-  const confirmBtn = document.getElementById('confirmBtn');
-  const input      = document.getElementById('answerInput');
-  confirmBtn.disabled = true;
-  input.disabled      = true;
+  lockInput();
 
   try {
     const res = await TestApi.submitAnswer(sessionId, currentQuestion.wordId, userInput);
     if (!res || !res.success) {
       showToast(res?.message || '오류가 발생했습니다.', 'error');
-      confirmBtn.disabled = false;
-      input.disabled      = false;
+      unlockInput();
       return;
     }
 
     // Jackson boolean 직렬화: isCorrect→correct, isFinished→finished
     const { correct, finished, nextQuestion } = res.data;
 
-    showFeedback(correct);
+    showFeedback(correct, userInput);
     updateDot(currentIndex, correct);
 
     setTimeout(async () => {
@@ -181,16 +224,23 @@ async function submitAnswer(userInput) {
     }, 800);
   } catch {
     showToast('네트워크 오류가 발생했습니다.', 'error');
-    confirmBtn.disabled = false;
-    input.disabled      = false;
+    unlockInput();
   }
 }
 
 // ── 정/오답 피드백 ────────────────────────────────────────────
-function showFeedback(isCorrect) {
-  const input = document.getElementById('answerInput');
-  input.style.borderColor = isCorrect ? 'var(--color-success)' : 'var(--color-danger)';
-  setTimeout(() => { input.style.borderColor = ''; }, 700);
+function showFeedback(isCorrect, userInput) {
+  if (currentQuizType === 'SHORT_ANSWER') {
+    const input = document.getElementById('answerInput');
+    input.style.borderColor = isCorrect ? 'var(--color-success)' : 'var(--color-danger)';
+    setTimeout(() => { input.style.borderColor = ''; }, 700);
+  } else {
+    document.querySelectorAll('#choicesGrid .choice-btn').forEach(btn => {
+      if (btn.dataset.choice === userInput) {
+        btn.classList.add(isCorrect ? 'correct' : 'wrong');
+      }
+    });
+  }
 }
 
 // ── 도트 인디케이터 ───────────────────────────────────────────

--- a/js/pages/test.js
+++ b/js/pages/test.js
@@ -5,6 +5,12 @@ import { showToast, formatDuration, formatDate, buildSidebar } from '../utils.js
 auth.requireLogin();
 buildSidebar('test');
 
+const QUIZ_TYPE_LABEL = {
+  SHORT_ANSWER:   '주관식',
+  MULTIPLE_CHOICE: '객관식',
+  FILL_IN_BLANK:  '빈칸채우기',
+};
+
 // ── 최근 기록 로드 ────────────────────────────────────────────
 async function loadRecentHistory() {
   try {
@@ -15,7 +21,6 @@ async function loadRecentHistory() {
     const listEl  = document.getElementById('recentHistoryList');
     const wrapEl  = document.getElementById('recentHistory');
 
-    const QUIZ_TYPE_LABEL = { SHORT_ANSWER: '주관식', MULTIPLE_CHOICE: '객관식' };
     listEl.innerHTML = records.map(r => {
       const accuracyClass = r.accuracy >= 80 ? 'high' : r.accuracy >= 50 ? 'mid' : 'low';
       return `
@@ -35,6 +40,24 @@ async function loadRecentHistory() {
 }
 
 loadRecentHistory();
+
+// ── 퀴즈 유형 선택 ───────────────────────────────────────────
+let selectedQuizType = 'SHORT_ANSWER';
+
+document.querySelectorAll('.chip[data-quiz-type]').forEach(chip => {
+  chip.addEventListener('click', () => {
+    // 1. 활성 칩 전환
+    document.querySelectorAll('.chip[data-quiz-type]').forEach(c => c.classList.remove('chip--active'));
+    chip.classList.add('chip--active');
+
+    // 2. 상태 업데이트
+    selectedQuizType = chip.dataset.quizType;
+
+    // 3. 가이드 패널 전환
+    document.querySelectorAll('.guide-content').forEach(g => { g.hidden = true; });
+    document.getElementById(`guide-${selectedQuizType}`).hidden = false;
+  });
+});
 
 // ── 상태 ─────────────────────────────────────────────────────
 let sessionId       = null;
@@ -67,7 +90,7 @@ async function startTest() {
   btn.textContent = '불러오는 중...';
 
   try {
-    const res = await TestApi.start(totalCount, 'SHORT_ANSWER');
+    const res = await TestApi.start(totalCount, selectedQuizType);
     if (!res || !res.success) {
       showToast(res?.message || '테스트를 시작할 수 없습니다.', 'error');
       return;

--- a/js/pages/test.js
+++ b/js/pages/test.js
@@ -41,7 +41,7 @@ async function loadRecentHistory() {
 
 loadRecentHistory();
 
-// ── 퀴즈 유형 선택 ───────────────────────────────────────────
+// ── 테스트 유형 선택 ──────────────────────────────────────────
 let selectedQuizType = 'SHORT_ANSWER';
 
 document.querySelectorAll('.chip[data-quiz-type]').forEach(chip => {
@@ -240,7 +240,7 @@ function renderResult(data) {
   const wrongSection = document.getElementById('wrongAnswerSection');
   if (wrongWords && wrongWords.length > 0) {
     wrongSection.hidden = false;
-    // 퀴즈 방향: 한글 뜻 표시 → 영단어 입력
+    // 테스트 방향: 한글 뜻 표시 → 영단어 입력
     // wrongWords[i]: { english(정답), korean(출제된 한글 뜻), userInput(내 답) }
     document.getElementById('wrongAnswerBody').innerHTML = wrongWords.map(w =>
       `<tr>

--- a/js/utils.js
+++ b/js/utils.js
@@ -235,7 +235,7 @@ export function createEyeSvg(size = 1) {
 //     {
 //       key: 'test',
 //       href: `${prefix}test.html`,
-//       label: '단어 퀴즈 세션',
+//       label: '단어 테스트 세션',
 //       icon: `<svg width="18" height="18" viewBox="0 0 18 18" fill="none">
 //         <circle cx="9" cy="9" r="7.5" stroke="currentColor" stroke-width="1.5"/>
 //         <circle cx="9" cy="9" r="3" fill="currentColor"/>
@@ -322,11 +322,11 @@ export function buildSidebar(activeMenu) {
 
   const navItems = isAdmin ? [
     { key: 'admin-word', href: `${prefix}admin/word-manage.html`, label: '단어장 관리', icon: '📝' },
-    { key: 'admin-quiz', href: `${prefix}admin/quiz-session.html`, label: '단어 퀴즈 세션', icon: '🎯' },
+    { key: 'admin-quiz', href: `${prefix}admin/quiz-session.html`, label: '단어 테스트 세션', icon: '🎯' },
   ] : [
     { key: 'dashboard', href: `${prefix}dashboard.html`, label: '내 대시보드', icon: '📊' },
     { key: 'word-list', href: `${prefix}word-list.html`, label: '단어장', icon: '📖' },
-    { key: 'test', href: `${prefix}test.html`, label: '단어 퀴즈', icon: '🎯' },
+    { key: 'test', href: `${prefix}test.html`, label: '단어 테스트', icon: '🎯' },
     { key: 'test-history', href: `${prefix}test-history.html`, label: '테스트 기록', icon: '📋' },
   ];
 

--- a/pages/admin/quiz-session.html
+++ b/pages/admin/quiz-session.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>퀴즈 세션 관리 - LookEng</title>
+  <title>테스트 세션 관리 - LookEng</title>
   <link rel="stylesheet" href="../../css/global.css" />
   <link rel="stylesheet" href="../../css/components.css" />
   <link rel="stylesheet" href="../../css/pages/admin.css" />
@@ -14,7 +14,7 @@
 
     <main class="layout__main">
       <div class="admin-page-header">
-        <h2 class="page-title">단어 퀴즈 세션</h2>
+        <h2 class="page-title">단어 테스트 세션</h2>
       </div>
 
       <!-- 유저 그리드 -->

--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -19,7 +19,7 @@
         <section class="welcome-card card">
           <h1 class="welcome-card__title">환영합니다! <span id="userName">User</span>님, 오늘도 달려볼까요? 🚀</h1>
           <div class="dashboard-actions">
-            <a href="./test.html" class="btn btn--primary btn--lg">퀴즈 시작하기</a>
+            <a href="./test.html" class="btn btn--primary btn--lg">테스트 시작하기</a>
             <a href="./word-list.html" class="btn btn--secondary btn--lg">단어장 보기</a>
           </div>
         </section>
@@ -39,8 +39,8 @@
             <p class="feature-card__desc">TOEIC 필수 단어를 확인하고 암기 상태를 관리하세요.</p>
           </div>
           <div class="feature-card card">
-            <h3 class="feature-card__title">단어 퀴즈</h3>
-            <p class="feature-card__desc">학습한 단어를 바탕으로 실전 퀴즈를 진행하세요.</p>
+            <h3 class="feature-card__title">단어 테스트</h3>
+            <p class="feature-card__desc">학습한 단어를 바탕으로 실전 테스트를 진행하세요.</p>
           </div>
         </section>
 

--- a/pages/test.html
+++ b/pages/test.html
@@ -210,6 +210,11 @@
           </div>
         </div>
 
+        <!-- 객관식/빈칸채우기 선택지 -->
+        <div id="choicesArea" hidden>
+          <div class="quiz-choices" id="choicesGrid"></div>
+        </div>
+
         <!-- 하단 도트 인디케이터 -->
         <div class="quiz-dots" id="quizDots"></div>
       </section>

--- a/pages/test.html
+++ b/pages/test.html
@@ -17,14 +17,14 @@
 
       <!-- 설정 화면 -->
       <section id="setupView">
-        <h1 class="page-title" style="margin-bottom: 24px;">단어 퀴즈 세션</h1>
+        <h1 class="page-title" style="margin-bottom: 24px;">단어 테스트 세션</h1>
 
         <!-- 상단: 설정 + 가이드 (같은 높이) -->
         <div class="setup-layout">
 
-          <!-- 왼쪽: 퀴즈 설정 -->
+          <!-- 왼쪽: 테스트 설정 -->
           <div class="setup-card">
-            <h2 class="setup-card__title">퀴즈 설정</h2>
+            <h2 class="setup-card__title">테스트 설정</h2>
 
             <div class="setup-field">
               <div class="setup-field__label">
@@ -36,10 +36,10 @@
               <div class="setup-field__hint">전체 단어 50개 중 랜덤으로 출제됩니다</div>
             </div>
 
-            <!-- 퀴즈 유형 선택 -->
+            <!-- 테스트 유형 선택 -->
             <div class="setup-field">
               <div class="setup-field__label">
-                <span>퀴즈 유형</span>
+                <span>테스트 유형</span>
               </div>
               <div class="chip-group">
                 <button class="chip chip--active" data-quiz-type="SHORT_ANSWER">주관식</button>
@@ -217,7 +217,7 @@
       <!-- 결과 화면 -->
       <section id="resultView" hidden>
         <div class="result-card">
-          <p class="result-card__title">퀴즈 결과</p>
+          <p class="result-card__title">테스트 결과</p>
           <div class="result-card__accuracy" id="resultAccuracy">0%</div>
           <p class="result-card__summary" id="resultSummary"></p>
 

--- a/pages/test.html
+++ b/pages/test.html
@@ -18,6 +18,8 @@
       <!-- 설정 화면 -->
       <section id="setupView">
         <h1 class="page-title" style="margin-bottom: 24px;">단어 퀴즈 세션</h1>
+
+        <!-- 상단: 설정 + 가이드 (같은 높이) -->
         <div class="setup-layout">
 
           <!-- 왼쪽: 퀴즈 설정 -->
@@ -34,58 +36,151 @@
               <div class="setup-field__hint">전체 단어 50개 중 랜덤으로 출제됩니다</div>
             </div>
 
-            <button class="btn btn--primary btn--full" id="startBtn" style="margin-top:16px">시작하기</button>
-
-            <!-- 최근 테스트 기록 -->
-            <div class="recent-history" id="recentHistory" hidden>
-              <p class="recent-history__title">최근 테스트 3개의 기록</p>
-              <div class="session-list" id="recentHistoryList"></div>
+            <!-- 퀴즈 유형 선택 -->
+            <div class="setup-field">
+              <div class="setup-field__label">
+                <span>퀴즈 유형</span>
+              </div>
+              <div class="chip-group">
+                <button class="chip chip--active" data-quiz-type="SHORT_ANSWER">주관식</button>
+                <button class="chip" data-quiz-type="MULTIPLE_CHOICE">객관식</button>
+                <button class="chip" data-quiz-type="FILL_IN_BLANK">빈칸채우기</button>
+              </div>
             </div>
+
+            <button class="btn btn--primary btn--full" id="startBtn">시작하기</button>
           </div>
 
-          <!-- 오른쪽: 테스트 설명 -->
+          <!-- 오른쪽: 유형별 가이드 -->
           <div class="setup-guide">
             <h2 class="setup-card__title">이렇게 진행돼요</h2>
 
-            <div class="guide-step">
-              <div class="guide-step__num">1</div>
-              <div class="guide-step__body">
-                <strong>한글 뜻이 카드로 표시됩니다</strong>
-                <p>품사와 예문도 함께 제공돼요</p>
-                <div class="guide-preview-card">
-                  <span class="guide-preview-card__pos">noun</span>
-                  <span class="guide-preview-card__word">사과</span>
-                  <span class="guide-preview-card__sentence">"I eat an apple every day."</span>
+            <!-- SHORT_ANSWER 가이드 -->
+            <div id="guide-SHORT_ANSWER" class="guide-content">
+              <div class="guide-step">
+                <div class="guide-step__num">1</div>
+                <div class="guide-step__body">
+                  <strong>한글 뜻이 카드로 표시됩니다</strong>
+                  <p>품사와 예문도 함께 제공돼요</p>
+                  <div class="guide-preview-card">
+                    <span class="guide-preview-card__pos">noun</span>
+                    <span class="guide-preview-card__word">사과</span>
+                    <span class="guide-preview-card__sentence">"I eat an apple every day."</span>
+                  </div>
+                </div>
+              </div>
+              <div class="guide-step">
+                <div class="guide-step__num">2</div>
+                <div class="guide-step__body">
+                  <strong>영단어를 직접 입력하세요</strong>
+                  <p>대소문자는 구분하지 않아요</p>
+                  <div class="guide-input-preview">
+                    <span class="guide-input-preview__text">apple</span>
+                    <span class="guide-input-preview__cursor"></span>
+                  </div>
+                </div>
+              </div>
+              <div class="guide-step">
+                <div class="guide-step__num">3</div>
+                <div class="guide-step__body">
+                  <strong>결과를 확인하세요</strong>
+                  <p>정답률 · 소요 시간 · 오답 목록을 확인할 수 있어요</p>
+                  <div class="guide-result-preview">
+                    <span class="guide-result-preview__score">80%</span>
+                    <span class="guide-result-preview__label">정답률</span>
+                  </div>
                 </div>
               </div>
             </div>
 
-            <div class="guide-step">
-              <div class="guide-step__num">2</div>
-              <div class="guide-step__body">
-                <strong>영단어를 직접 입력하세요</strong>
-                <p>대소문자는 구분하지 않아요</p>
-                <div class="guide-input-preview">
-                  <span class="guide-input-preview__text">apple</span>
-                  <span class="guide-input-preview__cursor"></span>
+            <!-- MULTIPLE_CHOICE 가이드 -->
+            <div id="guide-MULTIPLE_CHOICE" class="guide-content" hidden>
+              <div class="guide-step">
+                <div class="guide-step__num">1</div>
+                <div class="guide-step__body">
+                  <strong>한글 뜻이 카드로 표시됩니다</strong>
+                  <p>품사도 함께 제공돼요</p>
+                  <div class="guide-preview-card">
+                    <span class="guide-preview-card__pos">verb</span>
+                    <span class="guide-preview-card__word">버리다, 포기하다</span>
+                  </div>
+                </div>
+              </div>
+              <div class="guide-step">
+                <div class="guide-step__num">2</div>
+                <div class="guide-step__body">
+                  <strong>4개 보기 중 정답을 고르세요</strong>
+                  <p>서버가 정답 1개 + 오답 3개를 랜덤으로 섞어 제공해요</p>
+                  <div class="guide-choices-preview">
+                    <span class="guide-choice-item guide-choice-item--correct">abandon</span>
+                    <span class="guide-choice-item">achieve</span>
+                    <span class="guide-choice-item">analyze</span>
+                    <span class="guide-choice-item">approve</span>
+                  </div>
+                </div>
+              </div>
+              <div class="guide-step">
+                <div class="guide-step__num">3</div>
+                <div class="guide-step__body">
+                  <strong>결과를 확인하세요</strong>
+                  <p>정답률 · 소요 시간 · 오답 목록을 확인할 수 있어요</p>
+                  <div class="guide-result-preview">
+                    <span class="guide-result-preview__score">80%</span>
+                    <span class="guide-result-preview__label">정답률</span>
+                  </div>
                 </div>
               </div>
             </div>
 
-            <div class="guide-step">
-              <div class="guide-step__num">3</div>
-              <div class="guide-step__body">
-                <strong>결과를 확인하세요</strong>
-                <p>정답률 · 소요 시간 · 오답 목록을 확인할 수 있어요</p>
-                <div class="guide-result-preview">
-                  <span class="guide-result-preview__score">80%</span>
-                  <span class="guide-result-preview__label">정답률</span>
+            <!-- FILL_IN_BLANK 가이드 -->
+            <div id="guide-FILL_IN_BLANK" class="guide-content" hidden>
+              <div class="guide-step">
+                <div class="guide-step__num">1</div>
+                <div class="guide-step__body">
+                  <strong>빈칸이 있는 예문이 표시됩니다</strong>
+                  <p>예문 속 단어를 맞춰보세요</p>
+                  <div class="guide-preview-card">
+                    <span class="guide-preview-card__sentence" style="color:#fff; font-size:0.9rem; font-style:normal;">
+                      "He had to _____ his car in the snow."
+                    </span>
+                  </div>
+                </div>
+              </div>
+              <div class="guide-step">
+                <div class="guide-step__num">2</div>
+                <div class="guide-step__body">
+                  <strong>4개 보기 중 빈칸에 들어갈 단어를 고르세요</strong>
+                  <p>예문 문맥을 보고 정답을 추론해요</p>
+                  <div class="guide-choices-preview">
+                    <span class="guide-choice-item guide-choice-item--correct">abandon</span>
+                    <span class="guide-choice-item">achieve</span>
+                    <span class="guide-choice-item">analyze</span>
+                    <span class="guide-choice-item">approve</span>
+                  </div>
+                </div>
+              </div>
+              <div class="guide-step">
+                <div class="guide-step__num">3</div>
+                <div class="guide-step__body">
+                  <strong>결과를 확인하세요</strong>
+                  <p>정답률 · 소요 시간 · 오답 목록을 확인할 수 있어요</p>
+                  <div class="guide-result-preview">
+                    <span class="guide-result-preview__score">80%</span>
+                    <span class="guide-result-preview__label">정답률</span>
+                  </div>
                 </div>
               </div>
             </div>
 
           </div>
         </div>
+
+        <!-- 하단: 최근 테스트 기록 (독립 박스) -->
+        <div class="recent-history-box" id="recentHistory" hidden>
+          <p class="recent-history__title">최근 테스트 3개의 기록</p>
+          <div class="session-list" id="recentHistoryList"></div>
+        </div>
+
       </section>
 
       <!-- 진행 화면 -->

--- a/pages/test.html
+++ b/pages/test.html
@@ -48,7 +48,7 @@
               </div>
             </div>
 
-            <button class="btn btn--primary btn--full" id="startBtn">시작하기</button>
+            <button class="btn btn--primary btn--lg btn--full" id="startBtn">시작하기</button>
           </div>
 
           <!-- 오른쪽: 유형별 가이드 -->


### PR DESCRIPTION
## 관련 이슈

Closes #35

## 변경 사항 요약

### 1. 퀴즈 설정 화면 — 유형 선택 칩 + 동적 가이드 패널
- 테스트 유형 선택 칩 3개 추가: `주관식 / 객관식 / 빈칸채우기`
- 칩 클릭 시 우측 가이드 패널이 해당 유형으로 전환
- 시작하기 버튼이 선택된 `quizType`을 포함하여 API 호출

### 2. 퀴즈 진행 화면 — 유형별 분기
- `SHORT_ANSWER`: 한글 뜻 + 예문 카드, 텍스트 입력
- `MULTIPLE_CHOICE`: 한글 뜻 카드, 4지선다 버튼
- `FILL_IN_BLANK`: 빈칸 예문 강조 카드, 4지선다 버튼
- 선택지 클릭 → 정답/오답 색상 피드백 → 0.8초 후 다음 문제

### 3. 최근 테스트 기록 박스
- 설정 화면 하단 독립 박스에 최근 3개 기록 표시

### 4. 테스트 기록 페이지 — 유형 표시 한국어화 + 줄바꿈 방지
- `FILL_IN_BLANK` → `빈칸채우기` 한국어 표시
- `session-row__type` 배지 적용으로 줄바꿈 방지

### 5. UI 전체 용어 통일
- '퀴즈' → '테스트'로 전체 통일 (HTML, JS, CSS 포함)

## 변경 파일

| 파일 | 주요 변경 |
|------|----------|
| `pages/test.html` | 칩 그룹, 유형별 가이드 패널, 선택지 영역 추가 |
| `js/pages/test.js` | 칩 이벤트, 유형별 렌더링, 선택지 제출 로직 |
| `css/pages/test.css` | 칩·가이드·FIB 카드 스타일 |
| `js/pages/test-history.js` | FILL_IN_BLANK 매핑, 배지 적용 |
| `js/utils.js` · `pages/dashboard.html` 등 | 용어 통일 |

## 테스트 체크리스트

- [x] 유형 칩 3개 표시 및 전환 확인
- [x] 시작하기 → 선택된 quizType으로 API 호출 확인
- [x] 객관식: 4지선다 버튼 렌더링 및 정답/오답 피드백 확인
- [x] 빈칸채우기: 예문 카드 표시 및 선택지 동작 확인
- [x] 테스트 기록 페이지 빈칸채우기 한글 표시 확인
