### PR TITLE
✨ feat: 테스트 세션 상세 조회 모달 구현 (#3636)

### DIFF
--- a/css/pages/test.css
+++ b/css/pages/test.css
@@ -550,6 +550,35 @@
   color: var(--color-text-muted);
 }
 
+/* ── 테스트 세션 상세 모달 ── */
+.modal--detail { max-width: 680px; }
+
+.detail-summary {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: 4px;
+}
+.detail-summary__item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+.detail-summary__label {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+.detail-summary__value {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+.detail-summary__value--correct { color: var(--color-success); }
+.detail-summary__value--wrong   { color: var(--color-danger); }
+
 /* ── 하단 최근 기록: 타이틀 / 행 스타일 ── */
 .recent-history__title {
   font-size: 0.875rem;

--- a/js/api.js
+++ b/js/api.js
@@ -178,6 +178,10 @@ export const TestApi = {
   getHistory(page = 0, size = 10) {
     return request('GET', `/api/v1/test/sessions?page=${page}&size=${size}`);
   },
+
+  getSessionDetail(id) {
+    return request('GET', `/api/v1/test/sessions/${id}`);
+  },
 };
 
 // ── UserWord API ──────────────────────────────────────────────

--- a/js/pages/test-history.js
+++ b/js/pages/test-history.js
@@ -49,7 +49,7 @@ function renderTable(records) {
       <td><strong>${r.accuracy}%</strong></td>
       <td>${formatDuration(r.durationSec)}</td>
       <td>
-        <button class="btn btn--sm btn--secondary detail-btn"
+        <button class="btn btn--sm btn--primary detail-btn"
                 data-session-id="${r.sessionId}">상세</button>
       </td>
     </tr>

--- a/js/pages/test-history.js
+++ b/js/pages/test-history.js
@@ -7,6 +7,8 @@ buildSidebar('test-history');
 
 const PAGE_SIZE = 10;
 
+const QUIZ_TYPE_LABEL = { SHORT_ANSWER: '주관식', MULTIPLE_CHOICE: '객관식', FILL_IN_BLANK: '빈칸채우기' };
+
 async function loadHistory(page = 0) {
   try {
     const res = await TestApi.getHistory(page, PAGE_SIZE);
@@ -34,22 +36,112 @@ function renderTable(records) {
   if (!records || records.length === 0) {
     tbody.innerHTML = `
       <tr>
-        <td colspan="5" class="empty-state">아직 테스트 기록이 없습니다.</td>
+        <td colspan="6" class="empty-state">아직 테스트 기록이 없습니다.</td>
       </tr>`;
     return;
   }
 
-  const quizTypeLabel = { SHORT_ANSWER: '주관식', MULTIPLE_CHOICE: '객관식', FILL_IN_BLANK: '빈칸채우기' };
-
   tbody.innerHTML = records.map(r => `
     <tr>
       <td>${formatDate(r.startedAt)}</td>
-      <td><span class="session-row__type">${quizTypeLabel[r.quizType] ?? r.quizType}</span></td>
+      <td><span class="session-row__type">${QUIZ_TYPE_LABEL[r.quizType] ?? r.quizType}</span></td>
       <td>${r.totalCount}문제</td>
       <td><strong>${r.accuracy}%</strong></td>
       <td>${formatDuration(r.durationSec)}</td>
+      <td>
+        <button class="btn btn--sm btn--secondary detail-btn"
+                data-session-id="${r.sessionId}">상세</button>
+      </td>
     </tr>
   `).join('');
 }
 
 loadHistory(0);
+
+// ── 상세 모달 DOM 참조 ──────────────────────────────────────────
+const detailModal      = document.getElementById('detailModal');
+const detailModalTitle = document.getElementById('detailModalTitle');
+const detailSummary    = document.getElementById('detailSummary');
+const detailAnswerBody = document.getElementById('detailAnswerBody');
+
+// ── 상세 모달 열기 ─────────────────────────────────────────────
+async function openDetailModal(sessionId) {
+  detailModalTitle.textContent = '불러오는 중…';
+  detailSummary.innerHTML = '';
+  detailAnswerBody.innerHTML = '<tr><td colspan="5" class="empty-state">불러오는 중…</td></tr>';
+  detailModal.classList.add('is-open');
+
+  try {
+    const res = await TestApi.getSessionDetail(sessionId);
+    if (!res || !res.success) {
+      showToast(res?.message || '상세 정보를 불러오지 못했습니다.', 'error');
+      closeDetailModal();
+      return;
+    }
+    renderDetailModal(res.data);
+  } catch {
+    showToast('네트워크 오류가 발생했습니다.', 'error');
+    closeDetailModal();
+  }
+}
+
+// ── 상세 모달 렌더링 ────────────────────────────────────────────
+function renderDetailModal(data) {
+  detailModalTitle.textContent =
+    `${formatDate(data.createdAt)} — ${QUIZ_TYPE_LABEL[data.quizType] ?? data.quizType}`;
+
+  detailSummary.innerHTML = `
+    <div class="detail-summary__item">
+      <span class="detail-summary__label">유형</span>
+      <span class="detail-summary__value">
+        <span class="session-row__type">${QUIZ_TYPE_LABEL[data.quizType] ?? data.quizType}</span>
+      </span>
+    </div>
+    <div class="detail-summary__item">
+      <span class="detail-summary__label">점수</span>
+      <span class="detail-summary__value">${data.score} / ${data.totalQuestions}</span>
+    </div>
+    <div class="detail-summary__item">
+      <span class="detail-summary__label">정답</span>
+      <span class="detail-summary__value detail-summary__value--correct">${data.correctCount}</span>
+    </div>
+    <div class="detail-summary__item">
+      <span class="detail-summary__label">오답</span>
+      <span class="detail-summary__value detail-summary__value--wrong">${data.incorrectCount}</span>
+    </div>
+  `;
+
+  if (!data.answers?.length) {
+    detailAnswerBody.innerHTML = '<tr><td colspan="5" class="empty-state">답안 데이터가 없습니다.</td></tr>';
+    return;
+  }
+
+  detailAnswerBody.innerHTML = data.answers.map(a => `
+    <tr>
+      <td>${a.sequence}</td>
+      <td class="en">${a.english}</td>
+      <td>${a.korean}</td>
+      <td class="${a.correct ? '' : 'wrong-answer'}">${a.userAnswer ?? '(미입력)'}</td>
+      <td>${a.correct
+        ? '<span style="color:var(--color-success);font-weight:700">✓</span>'
+        : '<span style="color:var(--color-danger);font-weight:700">✗</span>'}</td>
+    </tr>
+  `).join('');
+}
+
+// ── 상세 모달 닫기 ─────────────────────────────────────────────
+function closeDetailModal() {
+  detailModal.classList.remove('is-open');
+}
+
+// ── 이벤트 바인딩 ─────────────────────────────────────────────
+document.getElementById('historyBody').addEventListener('click', (e) => {
+  const btn = e.target.closest('.detail-btn');
+  if (!btn) return;
+  openDetailModal(Number(btn.dataset.sessionId));
+});
+
+document.getElementById('detailModalClose').addEventListener('click', closeDetailModal);
+document.getElementById('detailModalCloseBtn').addEventListener('click', closeDetailModal);
+detailModal.addEventListener('click', (e) => { if (e.target === detailModal) closeDetailModal(); });
+document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeDetailModal(); });

--- a/pages/test-history.html
+++ b/pages/test-history.html
@@ -27,6 +27,7 @@
               <th>문제 수</th>
               <th>정답률</th>
               <th>소요 시간</th>
+              <th></th>
             </tr>
           </thead>
           <tbody id="historyBody"></tbody>
@@ -35,6 +36,32 @@
 
       <div class="pagination-wrapper" id="pagination"></div>
     </main>
+  </div>
+
+  <!-- 테스트 세션 상세 모달 -->
+  <div class="modal-overlay" id="detailModal">
+    <div class="modal modal--detail">
+      <div class="modal__header">
+        <h2 class="modal__title" id="detailModalTitle">테스트 상세</h2>
+        <button class="modal__close" id="detailModalClose">✕</button>
+      </div>
+      <div class="modal__body">
+        <div class="detail-summary" id="detailSummary"></div>
+        <div class="test-history-table-wrapper" style="margin-top:16px">
+          <table class="data-table">
+            <thead>
+              <tr>
+                <th>#</th><th>영단어</th><th>뜻</th><th>내 답안</th><th>결과</th>
+              </tr>
+            </thead>
+            <tbody id="detailAnswerBody"></tbody>
+          </table>
+        </div>
+      </div>
+      <div class="modal__footer">
+        <button class="btn btn--primary" id="detailModalCloseBtn">닫기</button>
+      </div>
+    </div>
   </div>
 
   <script type="module" src="../js/pages/test-history.js"></script>


### PR DESCRIPTION
## Related Issue

Closes #36

## Summary

- `TestApi.getSessionDetail(id)` 추가 — `GET /api/v1/test/sessions/{id}` 연동
- 테스트 기록 목록 각 행에 **상세** 버튼 추가 (서비스 주색 blue-primary 적용)
- 버튼 클릭 시 모달로 세션 상세 정보 표시
  - 요약 통계: 유형 / 점수 / 정답 수 / 오답 수
  - 문항별 답안 테이블: 순번 · 영단어 · 뜻 · 내 답안 · 정답 여부 (✓/✗)
- 모달 닫기: ✕ 버튼 / 닫기 버튼 / 오버레이 클릭 / ESC 키
- Java `boolean isCorrect` → Jackson 직렬화 시 `correct` 로 내려오는 이슈 수정

## Changed Files

| 파일 | 변경 내용 |
|------|---------|
| `js/api.js` | `TestApi.getSessionDetail(id)` 추가 |
| `pages/test-history.html` | 상세 버튼 `<th>` + 모달 HTML 추가 |
| `js/pages/test-history.js` | 상세 버튼 렌더링, 모달 열기/렌더링/닫기 로직 |
| `css/pages/test.css` | `.modal--detail`, `.detail-summary` 스타일 추가 |

## Test Plan

- [x] 테스트 기록 목록에서 각 행에 파란색 **상세** 버튼 노출 확인
- [x] 버튼 클릭 → 모달 열림, 해당 세션의 요약 통계 정확히 표시 확인
- [x] 문항별 답안 테이블에서 정답(✓ 초록) / 오답(✗ 빨강, 내 답안 빨간 텍스트) 표시 확인
- [x] 모달 닫기 4가지 방법 동작 확인 (✕ / 닫기 버튼 / 오버레이 / ESC)
- [x] 기록이 없는 경우 빈 상태 메시지 정상 표시 확인